### PR TITLE
fix(B002): pass temperature and model through routing path

### DIFF
--- a/docs-docusaurus/docs/reference/services/llm-service.md
+++ b/docs-docusaurus/docs/reference/services/llm-service.md
@@ -429,7 +429,7 @@ CodeBot,Review,Review code,llm,Done,Error,code,feedback,You are a code reviewer,
 
 `call_llm_many_async()` submits many LLM call specs in a single async call and returns one terminal result record per submitted spec. It reuses the existing async realtime path — routing, retries, timeouts, fallback, circuit-breaker, and E05-F01 cache-aware request support all apply per item.
 
-Existing single-call methods (`call_llm()`, `call_llm_async()`, `ask()`, `ask_async()`, `ask_vision()`) are unchanged. Fan-out is additive.
+Fan-out is additive. The synchronous `call_llm() -> str` and the high-level `ask()`, `ask_async()`, `ask_vision()` interfaces are unchanged. The internal `call_llm_async()` method now returns `LLMResponse` (carrying resolved provider, model, and usage) rather than a plain `str`; the public `ask_async()` method continues to return `str` by extracting `.text` from the response.
 
 ### Request shape
 
@@ -547,6 +547,39 @@ A single failing item does not cancel, abort, or modify sibling items. Each item
 - Pre-execution validation failures (empty submission, duplicate `spec_id`, invalid `max_concurrency`) raise `LLMServiceError` before any provider call begins.
 - Once execution starts, per-item errors are captured as `LLMCallResult` records with `status="failed"`. The submission-level `call_llm_many_async()` call does not re-raise item exceptions.
 - Sibling items continue to completion regardless of another item's failure.
+
+**Failure-path resolved identity**
+
+When a fan-out item fails *after* routing or fallback selected a concrete provider and model, the failure record carries that resolved identity:
+
+```python
+# Spec requests no specific provider — routing selects anthropic:claude-haiku.
+# The call then times out. The failure record still names the provider tried.
+spec = LLMCallSpec(
+    spec_id="routed-item",
+    messages=[{"role": "user", "content": "hello"}],
+    provider=None,  # routing chooses the provider
+    routing_context={"routing_enabled": True},
+)
+results = await llm_service.call_llm_many_async([spec], max_concurrency=1)
+r = results[0]
+assert r.status == "failed"
+assert r.provider == "anthropic"    # resolved before the failure
+assert r.model == "claude-haiku"    # resolved before the failure
+assert r.error.error_type == "LLMProviderError"
+```
+
+When failure occurs before any provider was selected (e.g., the routing service itself raises), `result.provider` and `result.model` remain `None` — they are never fabricated.
+
+This behaviour is implemented via the `LLMResolvedCallError` exception (subclass of `LLMServiceError`). The fan-out layer catches it and extracts the resolved identity. Single-call callers using `call_llm_async()` directly receive `LLMResolvedCallError` propagated unchanged; existing `except LLMServiceError` handlers continue to match.
+
+**`LLMResolvedCallError` attributes**
+
+| Attribute | Type | Description |
+|---|---|---|
+| `resolved_provider` | `Optional[str]` | The concrete provider that was attempted before the failure. |
+| `resolved_model` | `Optional[str]` | The concrete model that was attempted before the failure. |
+| `cause` | `BaseException` | The underlying typed exception (e.g. `LLMProviderError`, `LLMTimeoutError`) that triggered the failure. |
 
 ```python
 specs = [

--- a/docs-docusaurus/docs/reference/services/llm-service.md
+++ b/docs-docusaurus/docs/reference/services/llm-service.md
@@ -425,6 +425,165 @@ CodeBot,Review,Review code,llm,Done,Error,code,feedback,You are a code reviewer,
 
 ---
 
+## Async Fan-Out (`call_llm_many_async`)
+
+`call_llm_many_async()` submits many LLM call specs in a single async call and returns one terminal result record per submitted spec. It reuses the existing async realtime path — routing, retries, timeouts, fallback, circuit-breaker, and E05-F01 cache-aware request support all apply per item.
+
+Existing single-call methods (`call_llm()`, `call_llm_async()`, `ask()`, `ask_async()`, `ask_vision()`) are unchanged. Fan-out is additive.
+
+### Request shape
+
+```python
+from agentmap.models.llm_execution import LLMCallSpec, LLMCallResult, LLMUsage
+
+specs = [
+    # Direct provider item
+    LLMCallSpec(
+        spec_id="item-1",
+        messages=[{"role": "user", "content": "Translate to French: Hello"}],
+        provider="openai",
+        model="gpt-4o-mini",
+        temperature=0.3,
+    ),
+    # Routed item — routing selects provider and model
+    LLMCallSpec(
+        spec_id="item-2",
+        messages=[{"role": "user", "content": "Summarize this report."}],
+        routing_context={"task_type": "summarization"},
+    ),
+    # Cache-aware item (E05-F01 compatible)
+    LLMCallSpec(
+        spec_id="item-3",
+        messages=[
+            {"role": "system", "content": [{"type": "text", "text": "You are helpful."}]},
+            {"role": "user", "content": "What is 2+2?"},
+        ],
+        provider="anthropic",
+        request_options={"requires_prompt_caching": True, "cache_mode": "ephemeral"},
+    ),
+]
+
+results: list[LLMCallResult] = await llm_service.call_llm_many_async(
+    call_specs=specs,
+    max_concurrency=4,
+)
+```
+
+**`LLMCallSpec` fields**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `spec_id` | `str` | Yes | Unique identifier for this item within the submission. Must be unique across all items in a single call. |
+| `messages` | `List[Dict]` | Yes | Messages list in the same shape as `call_llm()`. Supports both plain string content and structured content blocks (E05-F01). |
+| `provider` | `Optional[str]` | No | Target provider for direct execution. Ignored when `routing_context` is provided. |
+| `model` | `Optional[str]` | No | Model override. Ignored when `routing_context` is provided. |
+| `temperature` | `Optional[float]` | No | Temperature override for this item. |
+| `routing_context` | `Optional[Dict]` | No | Routing context. When present, routing selects provider and model — same semantics as `call_llm()`. |
+| `request_options` | `Dict[str, Any]` | No | Additional keyword arguments forwarded to `call_llm_async()` unchanged. Use for cache-aware fields such as `requires_prompt_caching` and `cache_mode`. |
+
+### `spec_id` uniqueness rule
+
+Each `spec_id` must be unique within one `call_llm_many_async()` submission. Duplicate `spec_id` values cause the entire submission to fail before any provider call begins.
+
+### Concurrency limit (`max_concurrency`)
+
+`max_concurrency` caps the number of in-flight provider calls at any time. Must be an integer >= 1.
+
+- `max_concurrency=1` — fully sequential; no two items execute at the same time.
+- `max_concurrency=N` — up to N items execute concurrently.
+- The fan-out enforces this cap via `asyncio.Semaphore`; no item bypasses it.
+
+### Result shape
+
+`call_llm_many_async()` returns a `List[LLMCallResult]` with the same length and positional order as `call_specs`. Order is stable even when provider responses arrive out of order.
+
+```python
+for result in results:
+    if result.status == "succeeded":
+        print(f"{result.spec_id}: {result.content}")
+        if result.usage:
+            print(f"  tokens: {result.usage.input_tokens} in / {result.usage.output_tokens} out")
+            if result.usage.cache_read_input_tokens:
+                print(f"  cache read: {result.usage.cache_read_input_tokens} tokens")
+    else:
+        print(f"{result.spec_id} failed: {result.error.message} ({result.error.error_type})")
+```
+
+**`LLMCallResult` fields**
+
+| Field | Type | Description |
+|---|---|---|
+| `spec_id` | `str` | The `spec_id` from the originating `LLMCallSpec`. Always present, including on failure. |
+| `status` | `str` | `"succeeded"` or `"failed"`. |
+| `provider` | `Optional[str]` | Provider used for this item. `None` when routing failure prevented provider resolution. |
+| `model` | `Optional[str]` | Model used for this item. `None` when routing failure prevented model resolution. |
+| `content` | `Optional[str]` | Response text. Present only on success. |
+| `usage` | `Optional[LLMUsage]` | Normalized usage envelope. Present when the provider returned usage metadata. |
+| `error` | `Optional[LLMExecutionError]` | Structured error payload. Present only on failure. |
+
+**`LLMUsage` fields** (all `Optional[int]`)
+
+| Field | Description |
+|---|---|
+| `input_tokens` | Prompt tokens consumed. |
+| `output_tokens` | Completion tokens generated. |
+| `cache_creation_input_tokens` | Tokens written to the prompt cache (Anthropic cache-aware requests). |
+| `cache_read_input_tokens` | Tokens served from the prompt cache (Anthropic cache-aware requests). |
+
+Absent fields remain `None` rather than being filled with a default value.
+
+**`LLMExecutionError` fields**
+
+| Field | Type | Description |
+|---|---|---|
+| `error_type` | `str` | Exception class name (e.g. `"LLMTimeoutError"`, `"RuntimeError"`). |
+| `message` | `str` | Human-readable error message. |
+| `retryable` | `bool` | Whether the error class is retryable per the resilience configuration. |
+
+### Partial-failure semantics
+
+A single failing item does not cancel, abort, or modify sibling items. Each item is independent:
+
+- Pre-execution validation failures (empty submission, duplicate `spec_id`, invalid `max_concurrency`) raise `LLMServiceError` before any provider call begins.
+- Once execution starts, per-item errors are captured as `LLMCallResult` records with `status="failed"`. The submission-level `call_llm_many_async()` call does not re-raise item exceptions.
+- Sibling items continue to completion regardless of another item's failure.
+
+```python
+specs = [
+    LLMCallSpec(spec_id="ok", messages=[...], provider="openai"),
+    LLMCallSpec(spec_id="bad-cache", messages=[...], provider="openai",
+                request_options={"requires_prompt_caching": True}),
+]
+results = await llm_service.call_llm_many_async(specs, max_concurrency=2)
+# results[0].status == "succeeded"
+# results[1].status == "failed"  — unsupported cache mode on this provider
+```
+
+### Cache-aware requests (E05-F01 compatibility)
+
+Fan-out items fully support E05-F01 structured message content and cache-aware request options. Pass structured blocks and caching metadata through `request_options` — the fan-out layer forwards them unchanged to `call_llm_async()`:
+
+```python
+LLMCallSpec(
+    spec_id="cached-system",
+    messages=[
+        {
+            "role": "system",
+            "content": [
+                {"type": "text", "text": "Long system prompt...", "cache_control": {"type": "ephemeral"}}
+            ],
+        },
+        {"role": "user", "content": "Question here"},
+    ],
+    provider="anthropic",
+    request_options={"requires_prompt_caching": True},
+)
+```
+
+An unsupported cache mode (e.g. requesting prompt caching from a provider that does not support it) fails the item with the same `LLMServiceError` family as the single-call path, without affecting sibling items.
+
+---
+
 ## External Usage
 
 ```python

--- a/docs-docusaurus/docs/reference/services/llm-service.md
+++ b/docs-docusaurus/docs/reference/services/llm-service.md
@@ -566,7 +566,7 @@ r = results[0]
 assert r.status == "failed"
 assert r.provider == "anthropic"    # resolved before the failure
 assert r.model == "claude-haiku"    # resolved before the failure
-assert r.error.error_type == "LLMProviderError"
+assert r.error.error_type == "LLMTimeoutError"
 ```
 
 When failure occurs before any provider was selected (e.g., the routing service itself raises), `result.provider` and `result.model` remain `None` — they are never fabricated.
@@ -619,7 +619,7 @@ When a cache-aware item succeeds, the resolved provider and cache usage are both
 result = results[0]  # spec_id="cached-system"
 assert result.status == "succeeded"
 assert result.provider == "anthropic"           # resolved provider (after any routing)
-assert result.model == "claude-haiku-3"         # resolved model (after any routing)
+assert result.model == "claude-3-haiku"         # resolved model (after any routing)
 assert result.usage.cache_creation_input_tokens == 1024  # tokens written to cache
 assert result.usage.cache_read_input_tokens == 0         # first request — nothing cached yet
 # On a subsequent identical request:

--- a/docs-docusaurus/docs/reference/services/llm-service.md
+++ b/docs-docusaurus/docs/reference/services/llm-service.md
@@ -515,10 +515,10 @@ for result in results:
 |---|---|---|
 | `spec_id` | `str` | The `spec_id` from the originating `LLMCallSpec`. Always present, including on failure. |
 | `status` | `str` | `"succeeded"` or `"failed"`. |
-| `provider` | `Optional[str]` | Provider used for this item. `None` when routing failure prevented provider resolution. |
-| `model` | `Optional[str]` | Model used for this item. `None` when routing failure prevented model resolution. |
+| `provider` | `Optional[str]` | The provider that **actually handled** this item (after routing or fallback tier selection). `None` only when a routing failure occurred before provider resolution. |
+| `model` | `Optional[str]` | The model that **actually handled** this item (after routing or fallback tier selection). `None` only when a routing failure occurred before model resolution. |
 | `content` | `Optional[str]` | Response text. Present only on success. |
-| `usage` | `Optional[LLMUsage]` | Normalized usage envelope. Present when the provider returned usage metadata. |
+| `usage` | `Optional[LLMUsage]` | Normalized usage envelope. Present when the provider returned usage metadata. This includes routed and fallback items — the resolved provider's raw response is used to extract usage, so cache-aware fields such as `cache_read_input_tokens` are available on routed cache-aware requests. |
 | `error` | `Optional[LLMExecutionError]` | Structured error payload. Present only on failure. |
 
 **`LLMUsage` fields** (all `Optional[int]`)
@@ -578,6 +578,20 @@ LLMCallSpec(
     provider="anthropic",
     request_options={"requires_prompt_caching": True},
 )
+```
+
+When a cache-aware item succeeds, the resolved provider and cache usage are both visible on the result — even when routing selected a different model than the spec's nominal provider:
+
+```python
+result = results[0]  # spec_id="cached-system"
+assert result.status == "succeeded"
+assert result.provider == "anthropic"           # resolved provider (after any routing)
+assert result.model == "claude-haiku-3"         # resolved model (after any routing)
+assert result.usage.cache_creation_input_tokens == 1024  # tokens written to cache
+assert result.usage.cache_read_input_tokens == 0         # first request — nothing cached yet
+# On a subsequent identical request:
+# result.usage.cache_read_input_tokens == 1024  # served from cache
+# result.usage.cache_creation_input_tokens == 0
 ```
 
 An unsupported cache mode (e.g. requesting prompt caching from a provider that does not support it) fails the item with the same `LLMServiceError` family as the single-call path, without affecting sibling items.

--- a/docs/plan/bugs/B002.md
+++ b/docs/plan/bugs/B002.md
@@ -1,0 +1,45 @@
+---
+bug_key: B002
+title: Routing path silently drops temperature and model parameters passed to call_llm/call_llm_async
+status: draft
+severity: medium
+slug: routing-path-silently-drops-temperature-and-model
+---
+
+# Routing path silently drops temperature and model parameters passed to call_llm
+
+## Description
+
+When `call_llm` or `call_llm_async` is invoked with explicit `temperature` and/or `model` parameters and a `routing_context` is present, the routing methods (`_call_llm_with_routing`, `_call_llm_async_with_routing`) attempted to read these values from `kwargs` instead of the explicit parameters. Since `temperature` and `model` are extracted from the function signature before `**kwargs`, they were never in `kwargs`, so the lookup returned `None` and the caller's values were silently discarded.
+
+## Expected Behavior
+
+User-supplied `temperature` should be honored through the routing path, the same way it is honored through the direct (non-routing) path. The caller's `model` should be available as a fallback hint if routing fails.
+
+## Actual Behavior
+
+`temperature` was silently replaced with `None` in both the main and fallback routing paths (sync and async). `model` was also silently replaced with `None` in the fallback paths.
+
+## Steps to Reproduce
+
+1. Call `call_llm(messages, provider="openai", model="gpt-4o", temperature=0.0, routing_context=ctx)`
+2. Observe that the final `_call_llm_direct` call receives `temperature=None` and (in the fallback branch) `model=None`
+
+## Affected Locations (6 total)
+
+| File | Method | Lines | What's dropped |
+|------|--------|-------|---------------|
+| `llm_service.py` | `_call_llm_with_routing` main path | ~618 | `temperature` |
+| `llm_service.py` | `_call_llm_with_routing` fallback path | ~638-639 | `temperature`, `model` |
+| `llm_service.py` | `_call_llm_async_with_routing` main path | ~795 | `temperature` |
+| `llm_service.py` | `_call_llm_async_with_routing` fallback path | ~821-822 | `temperature`, `model` |
+
+## Root Cause
+
+`_call_llm_core` and `_call_llm_async_core` called the routing methods with only `**kwargs`, but `temperature` and `model` are explicit parameters that were already extracted from the function signature and are not present in the `kwargs` dict.
+
+## Fix Notes
+
+- Both `_call_llm_core` and `_call_llm_async_core` now pass `temperature` and `model` as explicit keyword arguments to the routing methods
+- Both `_call_llm_with_routing` and `_call_llm_async_with_routing` accept `temperature` and `model` as explicit parameters
+- All 6 `kwargs.get(...)` lookups replaced with the explicit parameter references

--- a/src/agentmap/exceptions/__init__.py
+++ b/src/agentmap/exceptions/__init__.py
@@ -31,6 +31,7 @@ from agentmap.exceptions.service_exceptions import (
     LLMDependencyError,
     LLMProviderError,
     LLMRateLimitError,
+    LLMResolvedCallError,
     LLMServiceError,
     LLMTimeoutError,
 )
@@ -74,6 +75,7 @@ __all__ = [
     "LLMDependencyError",
     "LLMTimeoutError",
     "LLMRateLimitError",
+    "LLMResolvedCallError",
     "StorageAuthenticationError",
     "StorageConnectionError",
     "StorageConfigurationError",

--- a/src/agentmap/exceptions/service_exceptions.py
+++ b/src/agentmap/exceptions/service_exceptions.py
@@ -2,6 +2,8 @@
 LLM Service exceptions for AgentMap.
 """
 
+from typing import Optional
+
 from agentmap.exceptions.base_exceptions import (
     AgentMapException,
     ConfigurationException,
@@ -30,6 +32,44 @@ class LLMTimeoutError(LLMProviderError):
 
 class LLMRateLimitError(LLMProviderError):
     """Exception raised on 429/rate limit errors (retryable)."""
+
+
+class LLMResolvedCallError(LLMServiceError):
+    """Raised when execution fails after a concrete provider/model was resolved.
+
+    Carries the resolved identity so the fan-out result builder (and any
+    single-call caller) can populate ``LLMCallResult.provider``/``.model``
+    with the provider that was actually attempted, not just the requested spec
+    values.  ``cause`` is the underlying typed error (e.g. ``LLMProviderError``,
+    ``LLMTimeoutError``) that triggered the failure.
+
+    Raise sites:
+    - ``LLMService._call_llm_async_direct`` — wraps all three failure exits
+      (typed-error early raise, fallback exhaustion re-wrap, terminal raise)
+      using the ``current_model`` resolved at that point.
+    - ``LLMFallbackHandler.try_with_fallback_async`` — raised on tier exhaustion,
+      carrying the last-attempted tier's identity (policy: last tier wins).
+
+    Catch site:
+    - ``LLMService._execute_fan_out_item`` — populates ``LLMCallResult.provider``
+      and ``.model`` from this exception's attributes.  The bare
+      ``except Exception`` block below it handles pre-resolution failures where
+      no concrete provider was selected.
+    """
+
+    def __init__(
+        self,
+        resolved_provider: Optional[str],
+        resolved_model: Optional[str],
+        cause: BaseException,
+    ) -> None:
+        self.resolved_provider = resolved_provider
+        self.resolved_model = resolved_model
+        self.cause = cause
+        super().__init__(
+            f"{type(cause).__name__} after resolving "
+            f"{resolved_provider}:{resolved_model} — {cause}"
+        )
 
 
 class StorageConfigurationNotAvailableException(ConfigurationException):

--- a/src/agentmap/models/llm_execution.py
+++ b/src/agentmap/models/llm_execution.py
@@ -15,8 +15,11 @@ class LLMResponse:
     """
     Internal seam result carrying the resolved provider identity and usage.
 
-    Returned by ``_call_llm_async_core`` and every private async method below
-    it. The public ``call_llm_async() -> str`` returns only ``.text``.
+    Returned by ``call_llm_async`` and every private async method below it
+    (``_call_llm_async_core``, ``_call_llm_async_direct``,
+    ``_call_llm_async_with_routing``, ``_invoke_with_resilience_async``).
+    The high-level ``ask_async()`` extracts ``.text`` and returns a plain
+    ``str`` to preserve its public contract.
 
     ``resolved_provider`` and ``resolved_model`` reflect the provider and model
     that **actually handled** the request — after routing rewrites or fallback

--- a/src/agentmap/models/llm_execution.py
+++ b/src/agentmap/models/llm_execution.py
@@ -10,6 +10,28 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 
+@dataclass(frozen=True)
+class LLMResponse:
+    """
+    Internal seam result carrying the resolved provider identity and usage.
+
+    Returned by ``_call_llm_async_core`` and every private async method below
+    it. The public ``call_llm_async() -> str`` returns only ``.text``.
+
+    ``resolved_provider`` and ``resolved_model`` reflect the provider and model
+    that **actually handled** the request — after routing rewrites or fallback
+    tier selection — not the values the caller specified.
+
+    ``usage`` is ``None`` only when the underlying provider did not return
+    ``usage_metadata`` on the response.
+    """
+
+    text: str
+    resolved_provider: str
+    resolved_model: str
+    usage: Optional["LLMUsage"] = None
+
+
 @dataclass
 class LLMCallSpec:
     """

--- a/src/agentmap/models/llm_execution.py
+++ b/src/agentmap/models/llm_execution.py
@@ -1,0 +1,77 @@
+"""
+Data-only execution models for fan-out and batch LLM call contracts.
+
+These models define the shared request and result envelope for multi-call
+execution modes introduced by E05-F02. They are intentionally data-only —
+no business logic lives here.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class LLMCallSpec:
+    """
+    Caller-owned specification for a single LLM call within a fan-out submission.
+
+    ``spec_id`` must be unique within one submission. The fan-out method uses it
+    to preserve input order and map results back to the originating spec.
+    """
+
+    spec_id: str
+    messages: List[Dict[str, Any]]
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    temperature: Optional[float] = None
+    routing_context: Optional[Dict[str, Any]] = None
+    request_options: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class LLMUsage:
+    """
+    Normalized per-item usage envelope.
+
+    Fields reflect what the realtime path can report. Absent fields remain
+    ``None`` rather than carrying fabricated defaults.
+    """
+
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    cache_creation_input_tokens: Optional[int] = None
+    cache_read_input_tokens: Optional[int] = None
+
+
+@dataclass
+class LLMExecutionError:
+    """
+    Structured error payload for a failed fan-out item.
+
+    Replaces raw uncaught exceptions so callers can inspect failure details
+    without catching submission-level exceptions.
+    """
+
+    error_type: str
+    message: str
+    retryable: bool
+
+
+@dataclass
+class LLMCallResult:
+    """
+    Terminal per-item result for a fan-out submission.
+
+    ``status`` is a closed terminal set: ``"succeeded"`` or ``"failed"``.
+    Successful results carry ``content`` and ``usage``; failed results carry
+    ``error``. ``provider`` and ``model`` may be ``None`` when the failure
+    occurs before provider resolution.
+    """
+
+    spec_id: str
+    status: str  # "succeeded" | "failed"
+    provider: Optional[str] = None
+    model: Optional[str] = None
+    content: Optional[str] = None
+    usage: Optional[LLMUsage] = None
+    error: Optional[LLMExecutionError] = None

--- a/src/agentmap/services/llm_fallback_handler.py
+++ b/src/agentmap/services/llm_fallback_handler.py
@@ -238,8 +238,14 @@ class LLMFallbackHandler:
         )
 
         attempted_fallbacks = []
-        # One-element mutable cell: [provider, model] of the last tier attempted.
+        # One-element mutable cell: [provider, model] of the last tier actually invoked.
+        # Updated immediately before _invoke_client_async in each tier helper so it
+        # only reflects providers where an actual network call was attempted.
         last_attempted = [original_provider, original_model]
+        # Mutable cell holding the last tier's typed exception for use as the
+        # cause in LLMResolvedCallError on exhaustion (MEDIUM-1 fix: preserve
+        # the typed error discriminator, not a synthetic LLMServiceError wrapper).
+        last_error = [error]
 
         if self.features_registry and self.features_registry.is_provider_available(
             "llm", original_provider
@@ -253,6 +259,7 @@ class LLMFallbackHandler:
                 get_or_create_client_fn,
                 convert_messages_fn,
                 last_attempted=last_attempted,
+                last_error=last_error,
             )
             if result is not None:
                 return result
@@ -275,6 +282,7 @@ class LLMFallbackHandler:
                     get_or_create_client_fn,
                     convert_messages_fn,
                     last_attempted=last_attempted,
+                    last_error=last_error,
                 )
                 if result is not None:
                     return result
@@ -293,6 +301,7 @@ class LLMFallbackHandler:
                 get_or_create_client_fn,
                 convert_messages_fn,
                 last_attempted=last_attempted,
+                last_error=last_error,
             )
             if result is not None:
                 return result
@@ -304,12 +313,15 @@ class LLMFallbackHandler:
             f"Original error: {error}"
         )
         self._logger.error(error_msg)
-        # Raise with the last-attempted tier identity so the caller can record
-        # which provider was actually invoked before exhaustion.
+        # Raise with the last-attempted tier identity and the last tier's typed
+        # error as cause. Using last_error[0] (the actual typed exception from the
+        # last invocation) rather than a synthetic LLMServiceError wrapper preserves
+        # the error discriminator (LLMTimeoutError, LLMRateLimitError, etc.) for
+        # callers that filter on LLMExecutionError.error_type (MEDIUM-1 fix).
         raise LLMResolvedCallError(
             resolved_provider=last_attempted[0],
             resolved_model=last_attempted[1],
-            cause=LLMServiceError(error_msg),
+            cause=last_error[0],
         )
 
     def _try_tier1_fallback(
@@ -371,6 +383,7 @@ class LLMFallbackHandler:
         get_or_create_client_fn: Any,
         convert_messages_fn: Any,
         last_attempted: Optional[List[str]] = None,
+        last_error: Optional[List[Exception]] = None,
     ) -> Optional[LLMResponse]:
         """Async Tier 1 fallback using the async resilience layer."""
         try:
@@ -381,14 +394,16 @@ class LLMFallbackHandler:
                     f"for provider '{original_provider}'"
                 )
                 attempted_fallbacks.append(f"{original_provider}:{fallback_model}")
-                if last_attempted is not None:
-                    last_attempted[0] = original_provider
-                    last_attempted[1] = fallback_model
 
                 config = get_provider_config_fn(original_provider)
                 config["model"] = fallback_model
                 client = get_or_create_client_fn(original_provider, config)
                 langchain_msgs = convert_messages_fn(messages)
+                # Update last_attempted immediately before the invocation so it
+                # reflects a provider that was actually called (MEDIUM-2 fix).
+                if last_attempted is not None:
+                    last_attempted[0] = original_provider
+                    last_attempted[1] = fallback_model
                 result = await self._invoke_client_async(
                     client, langchain_msgs, original_provider, fallback_model
                 )
@@ -397,6 +412,8 @@ class LLMFallbackHandler:
                 return result
         except Exception as e:
             self._logger.warning(f"Tier 1 fallback failed: {e}")
+            if last_error is not None:
+                last_error[0] = e
 
         return None
 
@@ -456,6 +473,7 @@ class LLMFallbackHandler:
         get_or_create_client_fn: Any,
         convert_messages_fn: Any,
         last_attempted: Optional[List[str]] = None,
+        last_error: Optional[List[Exception]] = None,
     ) -> Optional[LLMResponse]:
         """Async Tier 2 fallback using the async resilience layer."""
         try:
@@ -466,14 +484,16 @@ class LLMFallbackHandler:
                     f"'{fallback_provider}' and model '{fallback_model}'"
                 )
                 attempted_fallbacks.append(f"{fallback_provider}:{fallback_model}")
-                if last_attempted is not None:
-                    last_attempted[0] = fallback_provider
-                    last_attempted[1] = fallback_model
 
                 config = get_provider_config_fn(fallback_provider)
                 config["model"] = fallback_model
                 client = get_or_create_client_fn(fallback_provider, config)
                 langchain_msgs = convert_messages_fn(messages)
+                # Update last_attempted immediately before the invocation so it
+                # reflects a provider that was actually called (MEDIUM-2 fix).
+                if last_attempted is not None:
+                    last_attempted[0] = fallback_provider
+                    last_attempted[1] = fallback_model
                 result = await self._invoke_client_async(
                     client, langchain_msgs, fallback_provider, fallback_model
                 )
@@ -482,6 +502,8 @@ class LLMFallbackHandler:
                 return result
         except Exception as e:
             self._logger.warning(f"Tier 2 fallback failed: {e}")
+            if last_error is not None:
+                last_error[0] = e
 
         return None
 
@@ -549,6 +571,7 @@ class LLMFallbackHandler:
         get_or_create_client_fn: Any,
         convert_messages_fn: Any,
         last_attempted: Optional[List[str]] = None,
+        last_error: Optional[List[Exception]] = None,
     ) -> Optional[LLMResponse]:
         """Async Tier 3 fallback using the async resilience layer."""
         available_providers = self.features_registry.get_available_providers("llm")
@@ -564,14 +587,16 @@ class LLMFallbackHandler:
                         f"with model '{fallback_model}'"
                     )
                     attempted_fallbacks.append(f"{provider}:{fallback_model}")
-                    if last_attempted is not None:
-                        last_attempted[0] = provider
-                        last_attempted[1] = fallback_model
 
                     config = get_provider_config_fn(provider)
                     config["model"] = fallback_model
                     client = get_or_create_client_fn(provider, config)
                     langchain_msgs = convert_messages_fn(messages)
+                    # Update last_attempted immediately before the invocation so it
+                    # reflects a provider that was actually called (MEDIUM-2 fix).
+                    if last_attempted is not None:
+                        last_attempted[0] = provider
+                        last_attempted[1] = fallback_model
                     result = await self._invoke_client_async(
                         client, langchain_msgs, provider, fallback_model
                     )
@@ -580,5 +605,7 @@ class LLMFallbackHandler:
                     return result
             except Exception as e:
                 self._logger.warning(f"Tier 3 fallback failed for {provider}: {e}")
+                if last_error is not None:
+                    last_error[0] = e
 
         return None

--- a/src/agentmap/services/llm_fallback_handler.py
+++ b/src/agentmap/services/llm_fallback_handler.py
@@ -11,6 +11,7 @@ Handles multi-tier fallback logic when LLM calls fail, including:
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from agentmap.exceptions import LLMServiceError
+from agentmap.models.llm_execution import LLMResponse
 from agentmap.services.config.llm_routing_config_service import LLMRoutingConfigService
 from agentmap.services.features_registry_service import FeaturesRegistryService
 from agentmap.services.logging_service import LoggingService
@@ -63,13 +64,27 @@ class LLMFallbackHandler:
         langchain_messages: List[Any],
         provider: str,
         model: str,
-    ) -> str:
-        """Invoke client through the async resilience layer when available."""
+    ) -> LLMResponse:
+        """Invoke client through the async resilience layer.
+
+        When ``_invoke_async_fn`` is set (wired to
+        ``LLMService._invoke_with_resilience_async``), returns ``LLMResponse``
+        carrying the resolved provider, model, and usage extracted from the raw
+        response.  When no async fn is set, falls back to a bare sync invoke and
+        wraps the result in a minimal ``LLMResponse`` with no usage.
+        """
         if self._invoke_async_fn is not None:
             return await self._invoke_async_fn(
                 client, langchain_messages, provider, model
             )
-        return self._invoke_client(client, langchain_messages, provider, model)
+        # Bare fallback: no resilience layer available; wrap sync result.
+        text = self._invoke_client(client, langchain_messages, provider, model)
+        return LLMResponse(
+            text=text,
+            resolved_provider=provider,
+            resolved_model=model,
+            usage=None,
+        )
 
     def get_fallback_model(
         self, provider: str, complexity: str = "low"
@@ -207,8 +222,12 @@ class LLMFallbackHandler:
         get_or_create_client_fn: Any,
         convert_messages_fn: Any,
         **kwargs,
-    ) -> str:
-        """Async variant of tiered fallback preserving the sync fallback order."""
+    ) -> LLMResponse:
+        """Async variant of tiered fallback preserving the sync fallback order.
+
+        Returns ``LLMResponse`` carrying the resolved provider, model, and usage
+        from the winning fallback tier.
+        """
         self._logger.error(
             f"Model '{original_model}' failed for provider '{original_provider}': {error}"
         )
@@ -227,7 +246,7 @@ class LLMFallbackHandler:
                 get_or_create_client_fn,
                 convert_messages_fn,
             )
-            if result:
+            if result is not None:
                 return result
 
         if self.routing_config:
@@ -248,7 +267,7 @@ class LLMFallbackHandler:
                     get_or_create_client_fn,
                     convert_messages_fn,
                 )
-                if result:
+                if result is not None:
                     return result
 
         if self.features_registry:
@@ -265,7 +284,7 @@ class LLMFallbackHandler:
                 get_or_create_client_fn,
                 convert_messages_fn,
             )
-            if result:
+            if result is not None:
                 return result
 
         error_msg = (
@@ -335,7 +354,7 @@ class LLMFallbackHandler:
         get_provider_config_fn: Any,
         get_or_create_client_fn: Any,
         convert_messages_fn: Any,
-    ) -> Optional[str]:
+    ) -> Optional[LLMResponse]:
         """Async Tier 1 fallback using the async resilience layer."""
         try:
             fallback_model = self.get_fallback_model(original_provider, "low")
@@ -416,7 +435,7 @@ class LLMFallbackHandler:
         get_provider_config_fn: Any,
         get_or_create_client_fn: Any,
         convert_messages_fn: Any,
-    ) -> Optional[str]:
+    ) -> Optional[LLMResponse]:
         """Async Tier 2 fallback using the async resilience layer."""
         try:
             fallback_model = self.get_fallback_model(fallback_provider, "low")
@@ -505,7 +524,7 @@ class LLMFallbackHandler:
         get_provider_config_fn: Any,
         get_or_create_client_fn: Any,
         convert_messages_fn: Any,
-    ) -> Optional[str]:
+    ) -> Optional[LLMResponse]:
         """Async Tier 3 fallback using the async resilience layer."""
         available_providers = self.features_registry.get_available_providers("llm")
         for provider in available_providers:

--- a/src/agentmap/services/llm_fallback_handler.py
+++ b/src/agentmap/services/llm_fallback_handler.py
@@ -8,7 +8,7 @@ Handles multi-tier fallback logic when LLM calls fail, including:
 - Tier 4: Error with full context
 """
 
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from agentmap.exceptions import LLMServiceError
 from agentmap.services.config.llm_routing_config_service import LLMRoutingConfigService
@@ -25,6 +25,7 @@ class LLMFallbackHandler:
         routing_config: Optional[LLMRoutingConfigService] = None,
         features_registry: Optional[FeaturesRegistryService] = None,
         invoke_fn: Optional[Callable[..., str]] = None,
+        invoke_async_fn: Optional[Callable[..., Awaitable[str]]] = None,
     ):
         """
         Initialize fallback handler.
@@ -41,6 +42,7 @@ class LLMFallbackHandler:
         self.routing_config = routing_config
         self.features_registry = features_registry
         self._invoke_fn = invoke_fn
+        self._invoke_async_fn = invoke_async_fn
 
     def _invoke_client(
         self,
@@ -54,6 +56,20 @@ class LLMFallbackHandler:
             return self._invoke_fn(client, langchain_messages, provider, model)
         response = client.invoke(langchain_messages)
         return response.content if hasattr(response, "content") else str(response)
+
+    async def _invoke_client_async(
+        self,
+        client: Any,
+        langchain_messages: List[Any],
+        provider: str,
+        model: str,
+    ) -> str:
+        """Invoke client through the async resilience layer when available."""
+        if self._invoke_async_fn is not None:
+            return await self._invoke_async_fn(
+                client, langchain_messages, provider, model
+            )
+        return self._invoke_client(client, langchain_messages, provider, model)
 
     def get_fallback_model(
         self, provider: str, complexity: str = "low"
@@ -181,6 +197,86 @@ class LLMFallbackHandler:
         self._logger.error(error_msg)
         raise LLMServiceError(error_msg)
 
+    async def try_with_fallback_async(
+        self,
+        original_provider: str,
+        original_model: str,
+        messages: List[Dict[str, str]],
+        error: Exception,
+        get_provider_config_fn: Any,
+        get_or_create_client_fn: Any,
+        convert_messages_fn: Any,
+        **kwargs,
+    ) -> str:
+        """Async variant of tiered fallback preserving the sync fallback order."""
+        self._logger.error(
+            f"Model '{original_model}' failed for provider '{original_provider}': {error}"
+        )
+
+        attempted_fallbacks = []
+
+        if self.features_registry and self.features_registry.is_provider_available(
+            "llm", original_provider
+        ):
+            result = await self._try_tier1_fallback_async(
+                original_provider,
+                original_model,
+                messages,
+                attempted_fallbacks,
+                get_provider_config_fn,
+                get_or_create_client_fn,
+                convert_messages_fn,
+            )
+            if result:
+                return result
+
+        if self.routing_config:
+            fallback_provider = self.routing_config.fallback.get("default_provider")
+            if (
+                fallback_provider
+                and fallback_provider != original_provider
+                and self.features_registry
+                and self.features_registry.is_provider_available(
+                    "llm", fallback_provider
+                )
+            ):
+                result = await self._try_tier2_fallback_async(
+                    fallback_provider,
+                    messages,
+                    attempted_fallbacks,
+                    get_provider_config_fn,
+                    get_or_create_client_fn,
+                    convert_messages_fn,
+                )
+                if result:
+                    return result
+
+        if self.features_registry:
+            result = await self._try_tier3_fallback_async(
+                original_provider,
+                (
+                    self.routing_config.fallback.get("default_provider")
+                    if self.routing_config
+                    else None
+                ),
+                messages,
+                attempted_fallbacks,
+                get_provider_config_fn,
+                get_or_create_client_fn,
+                convert_messages_fn,
+            )
+            if result:
+                return result
+
+        error_msg = (
+            f"All fallback strategies exhausted for original request "
+            f"(provider: {original_provider}, model: {original_model}). "
+            f"Attempted fallbacks: {', '.join(attempted_fallbacks) if attempted_fallbacks else 'none'}. "
+            f"Original error: {error}"
+        )
+        self._logger.error(error_msg)
+        raise LLMServiceError(error_msg)
+
     def _try_tier1_fallback(
         self,
         original_provider: str,
@@ -230,6 +326,41 @@ class LLMFallbackHandler:
 
         return None
 
+    async def _try_tier1_fallback_async(
+        self,
+        original_provider: str,
+        original_model: str,
+        messages: List[Dict[str, str]],
+        attempted_fallbacks: List[str],
+        get_provider_config_fn: Any,
+        get_or_create_client_fn: Any,
+        convert_messages_fn: Any,
+    ) -> Optional[str]:
+        """Async Tier 1 fallback using the async resilience layer."""
+        try:
+            fallback_model = self.get_fallback_model(original_provider, "low")
+            if fallback_model and fallback_model != original_model:
+                self._logger.warning(
+                    f"Tier 1: Retrying with fallback model '{fallback_model}' "
+                    f"for provider '{original_provider}'"
+                )
+                attempted_fallbacks.append(f"{original_provider}:{fallback_model}")
+
+                config = get_provider_config_fn(original_provider)
+                config["model"] = fallback_model
+                client = get_or_create_client_fn(original_provider, config)
+                langchain_msgs = convert_messages_fn(messages)
+                result = await self._invoke_client_async(
+                    client, langchain_msgs, original_provider, fallback_model
+                )
+
+                self._logger.info("Tier 1 fallback successful")
+                return result
+        except Exception as e:
+            self._logger.warning(f"Tier 1 fallback failed: {e}")
+
+        return None
+
     def _try_tier2_fallback(
         self,
         fallback_provider: str,
@@ -267,6 +398,40 @@ class LLMFallbackHandler:
                 client = get_or_create_client_fn(fallback_provider, config)
                 langchain_msgs = convert_messages_fn(messages)
                 result = self._invoke_client(
+                    client, langchain_msgs, fallback_provider, fallback_model
+                )
+
+                self._logger.info("Tier 2 fallback successful")
+                return result
+        except Exception as e:
+            self._logger.warning(f"Tier 2 fallback failed: {e}")
+
+        return None
+
+    async def _try_tier2_fallback_async(
+        self,
+        fallback_provider: str,
+        messages: List[Dict[str, str]],
+        attempted_fallbacks: List[str],
+        get_provider_config_fn: Any,
+        get_or_create_client_fn: Any,
+        convert_messages_fn: Any,
+    ) -> Optional[str]:
+        """Async Tier 2 fallback using the async resilience layer."""
+        try:
+            fallback_model = self.get_fallback_model(fallback_provider, "low")
+            if fallback_model:
+                self._logger.warning(
+                    f"Tier 2: Retrying with configured fallback provider "
+                    f"'{fallback_provider}' and model '{fallback_model}'"
+                )
+                attempted_fallbacks.append(f"{fallback_provider}:{fallback_model}")
+
+                config = get_provider_config_fn(fallback_provider)
+                config["model"] = fallback_model
+                client = get_or_create_client_fn(fallback_provider, config)
+                langchain_msgs = convert_messages_fn(messages)
+                result = await self._invoke_client_async(
                     client, langchain_msgs, fallback_provider, fallback_model
                 )
 
@@ -325,6 +490,46 @@ class LLMFallbackHandler:
                     )
 
                     self._logger.info("Tier 3 emergency fallback successful")
+                    return result
+            except Exception as e:
+                self._logger.warning(f"Tier 3 fallback failed for {provider}: {e}")
+
+        return None
+
+    async def _try_tier3_fallback_async(
+        self,
+        original_provider: str,
+        configured_fallback_provider: Optional[str],
+        messages: List[Dict[str, str]],
+        attempted_fallbacks: List[str],
+        get_provider_config_fn: Any,
+        get_or_create_client_fn: Any,
+        convert_messages_fn: Any,
+    ) -> Optional[str]:
+        """Async Tier 3 fallback using the async resilience layer."""
+        available_providers = self.features_registry.get_available_providers("llm")
+        for provider in available_providers:
+            if provider in [original_provider, configured_fallback_provider]:
+                continue
+
+            try:
+                fallback_model = self.get_fallback_model(provider, "low")
+                if fallback_model:
+                    self._logger.warning(
+                        f"Tier 3: Emergency fallback to provider '{provider}' "
+                        f"with model '{fallback_model}'"
+                    )
+                    attempted_fallbacks.append(f"{provider}:{fallback_model}")
+
+                    config = get_provider_config_fn(provider)
+                    config["model"] = fallback_model
+                    client = get_or_create_client_fn(provider, config)
+                    langchain_msgs = convert_messages_fn(messages)
+                    result = await self._invoke_client_async(
+                        client, langchain_msgs, provider, fallback_model
+                    )
+
+                    self._logger.info("Tier 3 fallback successful")
                     return result
             except Exception as e:
                 self._logger.warning(f"Tier 3 fallback failed for {provider}: {e}")

--- a/src/agentmap/services/llm_fallback_handler.py
+++ b/src/agentmap/services/llm_fallback_handler.py
@@ -11,6 +11,7 @@ Handles multi-tier fallback logic when LLM calls fail, including:
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from agentmap.exceptions import LLMServiceError
+from agentmap.exceptions.service_exceptions import LLMResolvedCallError
 from agentmap.models.llm_execution import LLMResponse
 from agentmap.services.config.llm_routing_config_service import LLMRoutingConfigService
 from agentmap.services.features_registry_service import FeaturesRegistryService
@@ -227,12 +228,18 @@ class LLMFallbackHandler:
 
         Returns ``LLMResponse`` carrying the resolved provider, model, and usage
         from the winning fallback tier.
+
+        On exhaustion, raises ``LLMResolvedCallError`` carrying the last-attempted
+        tier's identity (policy: last tier wins — the most recent concrete provider
+        invoked is the most relevant for observability and debugging).
         """
         self._logger.error(
             f"Model '{original_model}' failed for provider '{original_provider}': {error}"
         )
 
         attempted_fallbacks = []
+        # One-element mutable cell: [provider, model] of the last tier attempted.
+        last_attempted = [original_provider, original_model]
 
         if self.features_registry and self.features_registry.is_provider_available(
             "llm", original_provider
@@ -245,6 +252,7 @@ class LLMFallbackHandler:
                 get_provider_config_fn,
                 get_or_create_client_fn,
                 convert_messages_fn,
+                last_attempted=last_attempted,
             )
             if result is not None:
                 return result
@@ -266,6 +274,7 @@ class LLMFallbackHandler:
                     get_provider_config_fn,
                     get_or_create_client_fn,
                     convert_messages_fn,
+                    last_attempted=last_attempted,
                 )
                 if result is not None:
                     return result
@@ -283,6 +292,7 @@ class LLMFallbackHandler:
                 get_provider_config_fn,
                 get_or_create_client_fn,
                 convert_messages_fn,
+                last_attempted=last_attempted,
             )
             if result is not None:
                 return result
@@ -294,7 +304,13 @@ class LLMFallbackHandler:
             f"Original error: {error}"
         )
         self._logger.error(error_msg)
-        raise LLMServiceError(error_msg)
+        # Raise with the last-attempted tier identity so the caller can record
+        # which provider was actually invoked before exhaustion.
+        raise LLMResolvedCallError(
+            resolved_provider=last_attempted[0],
+            resolved_model=last_attempted[1],
+            cause=LLMServiceError(error_msg),
+        )
 
     def _try_tier1_fallback(
         self,
@@ -354,6 +370,7 @@ class LLMFallbackHandler:
         get_provider_config_fn: Any,
         get_or_create_client_fn: Any,
         convert_messages_fn: Any,
+        last_attempted: Optional[List[str]] = None,
     ) -> Optional[LLMResponse]:
         """Async Tier 1 fallback using the async resilience layer."""
         try:
@@ -364,6 +381,9 @@ class LLMFallbackHandler:
                     f"for provider '{original_provider}'"
                 )
                 attempted_fallbacks.append(f"{original_provider}:{fallback_model}")
+                if last_attempted is not None:
+                    last_attempted[0] = original_provider
+                    last_attempted[1] = fallback_model
 
                 config = get_provider_config_fn(original_provider)
                 config["model"] = fallback_model
@@ -435,6 +455,7 @@ class LLMFallbackHandler:
         get_provider_config_fn: Any,
         get_or_create_client_fn: Any,
         convert_messages_fn: Any,
+        last_attempted: Optional[List[str]] = None,
     ) -> Optional[LLMResponse]:
         """Async Tier 2 fallback using the async resilience layer."""
         try:
@@ -445,6 +466,9 @@ class LLMFallbackHandler:
                     f"'{fallback_provider}' and model '{fallback_model}'"
                 )
                 attempted_fallbacks.append(f"{fallback_provider}:{fallback_model}")
+                if last_attempted is not None:
+                    last_attempted[0] = fallback_provider
+                    last_attempted[1] = fallback_model
 
                 config = get_provider_config_fn(fallback_provider)
                 config["model"] = fallback_model
@@ -524,6 +548,7 @@ class LLMFallbackHandler:
         get_provider_config_fn: Any,
         get_or_create_client_fn: Any,
         convert_messages_fn: Any,
+        last_attempted: Optional[List[str]] = None,
     ) -> Optional[LLMResponse]:
         """Async Tier 3 fallback using the async resilience layer."""
         available_providers = self.features_registry.get_available_providers("llm")
@@ -539,6 +564,9 @@ class LLMFallbackHandler:
                         f"with model '{fallback_model}'"
                     )
                     attempted_fallbacks.append(f"{provider}:{fallback_model}")
+                    if last_attempted is not None:
+                        last_attempted[0] = provider
+                        last_attempted[1] = fallback_model
 
                     config = get_provider_config_fn(provider)
                     config["model"] = fallback_model

--- a/src/agentmap/services/llm_service.py
+++ b/src/agentmap/services/llm_service.py
@@ -465,7 +465,11 @@ class LLMService:
                     "routing_context['fallback_provider'] to set the fallback."
                 )
             return self._call_llm_with_routing(
-                messages, routing_context, temperature=temperature, model=model, **kwargs
+                messages,
+                routing_context,
+                temperature=temperature,
+                model=model,
+                **kwargs,
             )
         if not provider:
             raise LLMServiceError(
@@ -509,7 +513,11 @@ class LLMService:
                     "routing_context['fallback_provider'] to set the fallback."
                 )
             return await self._call_llm_async_with_routing(
-                messages, routing_context, temperature=temperature, model=model, **kwargs
+                messages,
+                routing_context,
+                temperature=temperature,
+                model=model,
+                **kwargs,
             )
         if not provider:
             raise LLMServiceError(

--- a/src/agentmap/services/llm_service.py
+++ b/src/agentmap/services/llm_service.py
@@ -24,6 +24,7 @@ from agentmap.models.llm_execution import (
     LLMCallResult,
     LLMCallSpec,
     LLMExecutionError,
+    LLMResponse,
     LLMUsage,
 )
 from agentmap.services.config import AppConfigService
@@ -31,7 +32,11 @@ from agentmap.services.config.llm_models_config_service import LLMModelsConfigSe
 from agentmap.services.config.llm_routing_config_service import LLMRoutingConfigService
 from agentmap.services.features_registry_service import FeaturesRegistryService
 from agentmap.services.llm_client_factory import LLMClientFactory
-from agentmap.services.llm_error_utils import classify_llm_error, is_retryable
+from agentmap.services.llm_error_utils import (
+    _sanitize_error_message,
+    classify_llm_error,
+    is_retryable,
+)
 from agentmap.services.llm_fallback_handler import LLMFallbackHandler
 from agentmap.services.llm_message_utils import LLMMessageUtils
 from agentmap.services.llm_provider_utils import LLMProviderUtils
@@ -116,12 +121,17 @@ class LLMService:
         self._provider_utils = LLMProviderUtils(
             configuration, llm_models_config_service, logging_service
         )
+        # Use lambda so the fallback handler always dispatches through the
+        # current binding of _invoke_with_resilience_async (important for
+        # tests that patch the method after construction).
         self._fallback_handler = LLMFallbackHandler(
             logging_service,
             routing_config_service,
             features_registry_service,
             invoke_fn=self._invoke_with_resilience,
-            invoke_async_fn=self._invoke_with_resilience_async,
+            invoke_async_fn=lambda client, msgs, provider, model: self._invoke_with_resilience_async(
+                client, msgs, provider, model
+            ),
         )
         self._message_utils = LLMMessageUtils()
 
@@ -269,9 +279,14 @@ class LLMService:
         temperature: Optional[float] = None,
         routing_context: Optional[Dict[str, Any]] = None,
         **kwargs,
-    ) -> str:
+    ) -> LLMResponse:
         """
-        Make an async LLM call with the same public contract as ``call_llm()``.
+        Make an async LLM call and return a rich ``LLMResponse``.
+
+        ``LLMResponse.text`` carries the response text; ``.resolved_provider``
+        and ``.resolved_model`` reflect the provider and model that **actually
+        handled** the request (after routing or fallback); ``.usage`` carries
+        normalized token counts when the provider returned usage metadata.
 
         When routing_context is provided, routing owns all provider and model
         selection. Explicit provider and model inputs are ignored with the same
@@ -293,7 +308,7 @@ class LLMService:
         temperature: Optional[float],
         routing_context: Optional[Dict[str, Any]],
         **kwargs,
-    ) -> str:
+    ) -> LLMResponse:
         """Async telemetry wrapper mirroring the sync LLM span behavior."""
         initial_attributes: Dict[str, Any] = {}
         if provider:
@@ -317,7 +332,7 @@ class LLMService:
                         routing_context,
                         **kwargs,
                     )
-                    self._capture_llm_content(span, messages, result)
+                    self._capture_llm_content(span, messages, result.text)
                     self._set_span_status_ok(span)
                     return result
                 except Exception as e:
@@ -462,8 +477,13 @@ class LLMService:
         temperature: Optional[float],
         routing_context: Optional[Dict[str, Any]],
         **kwargs,
-    ) -> str:
-        """Async sibling of ``_call_llm_core`` for the staged migration."""
+    ) -> LLMResponse:
+        """Single async seam shared by ``call_llm_async`` and the fan-out path.
+
+        Returns a rich ``LLMResponse`` carrying the resolved provider identity
+        and usage.  Both public entrypoints delegate here; there is exactly one
+        async resilience stack.
+        """
         if routing_context is not None and self.routing_service:
             if model is not None:
                 self._logger.warning(
@@ -695,8 +715,12 @@ class LLMService:
 
     async def _call_llm_async_with_routing(
         self, messages: List[Dict[str, str]], routing_context: Dict[str, Any], **kwargs
-    ) -> str:
-        """Async sibling of ``_call_llm_with_routing`` preserving routing rules."""
+    ) -> LLMResponse:
+        """Async sibling of ``_call_llm_with_routing`` preserving routing rules.
+
+        Delegates to ``_call_llm_async_direct`` which returns ``LLMResponse``
+        carrying the resolved provider, model, and usage from the raw response.
+        """
         if not self.routing_service:
             raise LLMServiceError("Routing requested but no routing service available")
 
@@ -783,8 +807,12 @@ class LLMService:
         model: Optional[str] = None,
         temperature: Optional[float] = None,
         **kwargs,
-    ) -> str:
-        """Async direct provider invocation with resilience and fallback parity."""
+    ) -> LLMResponse:
+        """Async direct provider invocation with resilience and fallback parity.
+
+        Returns ``LLMResponse`` carrying the resolved provider, model, and usage
+        extracted from the raw provider response.
+        """
         provider = self._provider_utils.normalize_provider(provider)
         config = self._provider_utils.get_provider_config(provider)
 
@@ -953,98 +981,13 @@ class LLMService:
         langchain_messages: List[Any],
         provider: str,
         model: str,
-    ) -> str:
-        """Async sibling of ``_invoke_with_resilience`` using awaited backoff."""
-        self._record_circuit_breaker_state(provider, model)
+    ) -> LLMResponse:
+        """Single async resilience seam: retry + circuit breaker + response wrapping.
 
-        if self._circuit_breaker.is_open(provider, model):
-            raise LLMProviderError(
-                f"Circuit breaker open for {provider}:{model} -- "
-                f"skipping call (resets after "
-                f"{self._circuit_breaker.reset}s)"
-            )
-
-        retry_cfg = self._resilience_config.get("retry", {})
-        max_attempts = retry_cfg.get("max_attempts", 3)
-        backoff_base = retry_cfg.get("backoff_base", 2.0)
-        backoff_max = retry_cfg.get("backoff_max", 30.0)
-        jitter = retry_cfg.get("jitter", True)
-
-        last_error: Optional[Exception] = None
-
-        for attempt in range(1, max_attempts + 1):
-            try:
-                self._logger.debug(
-                    f"LLM call to {provider}:{model} "
-                    f"(attempt {attempt}/{max_attempts})"
-                )
-                start_time = time.monotonic()
-                response = await self._invoke_provider_async(client, langchain_messages)
-                duration = time.monotonic() - start_time
-
-                result = (
-                    response.content if hasattr(response, "content") else str(response)
-                )
-
-                was_open = self._circuit_breaker.is_open(provider, model)
-                self._circuit_breaker.record_success(provider, model)
-                self._record_circuit_breaker_metric_on_close(was_open, provider, model)
-                self._record_duration_metric(duration, provider, model)
-                self._record_llm_response_attributes(response, provider, model)
-
-                resp_meta = getattr(response, "response_metadata", None)
-                req_id = (
-                    self._extract_provider_request_id(resp_meta, provider)
-                    if isinstance(resp_meta, dict)
-                    else None
-                )
-                self._logger.debug(
-                    f"LLM call successful, response length: {len(result)}"
-                    + (f", request_id: {req_id}" if req_id else "")
-                )
-                return result
-            except Exception as e:
-                typed_error = classify_llm_error(e, provider)
-                last_error = typed_error
-
-                if not is_retryable(typed_error):
-                    self._circuit_breaker.record_failure(provider, model)
-                    self._record_error_metric(typed_error, provider, model)
-                    self._record_circuit_breaker_metric_on_open(provider, model)
-                    raise typed_error
-
-                if attempt == max_attempts:
-                    break
-
-                delay = min(backoff_base ** (attempt - 1), backoff_max)
-                if jitter:
-                    delay = delay * (0.5 + random.random())
-
-                self._logger.warning(
-                    f"Retryable error on {provider}:{model} "
-                    f"(attempt {attempt}/{max_attempts}): {typed_error}. "
-                    f"Retrying in {delay:.1f}s"
-                )
-                await asyncio.sleep(delay)
-
-        self._circuit_breaker.record_failure(provider, model)
-        self._record_error_metric(last_error, provider, model)
-        self._record_circuit_breaker_metric_on_open(provider, model)
-        raise last_error  # type: ignore[misc]
-
-    async def _invoke_with_resilience_async_with_response(
-        self,
-        client: Any,
-        langchain_messages: List[Any],
-        provider: str,
-        model: str,
-    ) -> Tuple[str, Any]:
-        """Async resilience wrapper that also returns the raw provider response.
-
-        This is the lower seam used by the fan-out path so that per-item usage
-        metadata (``usage_metadata``) is preserved alongside the text result.
-        It mirrors ``_invoke_with_resilience_async`` exactly except it returns
-        ``(text, raw_response)`` instead of just ``text``.
+        Returns ``LLMResponse`` carrying the resolved ``provider``, ``model``,
+        response text, and normalized ``LLMUsage`` extracted from the raw response.
+        This is the **only** async resilience stack — the fan-out path and the
+        public ``call_llm_async`` both funnel through here.
         """
         self._record_circuit_breaker_state(provider, model)
 
@@ -1073,7 +1016,7 @@ class LLMService:
                 response = await self._invoke_provider_async(client, langchain_messages)
                 duration = time.monotonic() - start_time
 
-                result = (
+                text = (
                     response.content if hasattr(response, "content") else str(response)
                 )
 
@@ -1090,10 +1033,15 @@ class LLMService:
                     else None
                 )
                 self._logger.debug(
-                    f"LLM call successful, response length: {len(result)}"
+                    f"LLM call successful, response length: {len(text)}"
                     + (f", request_id: {req_id}" if req_id else "")
                 )
-                return result, response
+                return LLMResponse(
+                    text=text,
+                    resolved_provider=provider,
+                    resolved_model=model,
+                    usage=self._extract_llm_usage(response),
+                )
             except Exception as e:
                 typed_error = classify_llm_error(e, provider)
                 last_error = typed_error
@@ -1122,109 +1070,6 @@ class LLMService:
         self._record_error_metric(last_error, provider, model)
         self._record_circuit_breaker_metric_on_open(provider, model)
         raise last_error  # type: ignore[misc]
-
-    async def _call_llm_async_direct_with_response(
-        self,
-        provider: str,
-        messages: List[Dict[str, str]],
-        model: Optional[str] = None,
-        temperature: Optional[float] = None,
-        **kwargs,
-    ) -> Tuple[str, Any]:
-        """Variant of ``_call_llm_async_direct`` returning ``(text, raw_response)``.
-
-        Used by the fan-out path so that ``usage_metadata`` on the raw response
-        object survives into ``_execute_fan_out_item`` for normalization into
-        ``LLMCallResult.usage``.  The public ``call_llm_async`` contract (returns
-        ``str``) is unchanged.
-        """
-        provider = self._provider_utils.normalize_provider(provider)
-        config = self._provider_utils.get_provider_config(provider)
-
-        max_tokens = kwargs.pop("max_tokens", None)
-        if model or temperature is not None or max_tokens is not None:
-            config = config.copy()
-            if model:
-                config["model"] = model
-            if temperature is not None:
-                config["temperature"] = temperature
-            if max_tokens == 0:
-                config.pop("max_tokens", None)
-            elif max_tokens is not None:
-                config["max_tokens"] = max_tokens
-
-        current_model = config.get("model", "unknown")
-
-        try:
-            client = self._client_factory.get_or_create_client(provider, config)
-            langchain_messages = self._message_utils.convert_messages_to_langchain(
-                messages
-            )
-            return await self._invoke_with_resilience_async_with_response(
-                client, langchain_messages, provider, current_model
-            )
-        except Exception as e:
-            typed_error = classify_llm_error(e, provider)
-
-            if isinstance(typed_error, (LLMDependencyError, LLMConfigurationError)):
-                raise typed_error
-
-            if self.features_registry and self.routing_config:
-                try:
-                    # Fallback path returns str only; return (text, None) since
-                    # the raw response is not accessible through the fallback seam.
-                    fallback_text = (
-                        await self._fallback_handler.try_with_fallback_async(
-                            provider,
-                            current_model,
-                            messages,
-                            typed_error,
-                            self._provider_utils.get_provider_config,
-                            self._client_factory.get_or_create_client,
-                            self._message_utils.convert_messages_to_langchain,
-                            **kwargs,
-                        )
-                    )
-                    return fallback_text, None
-                except LLMServiceError:
-                    pass
-
-            raise typed_error
-
-    async def _call_llm_async_with_response(
-        self,
-        messages: List[Dict[str, str]],
-        provider: Optional[str],
-        model: Optional[str],
-        temperature: Optional[float],
-        routing_context: Optional[Dict[str, Any]],
-        **kwargs,
-    ) -> Tuple[str, Any]:
-        """Internal seam for fan-out: returns ``(text, raw_response)``.
-
-        When ``routing_context`` is active, the raw response is not available
-        through the routing stack so ``raw_response`` will be ``None``.  The
-        fan-out caller must tolerate ``None`` and produce ``usage=None`` in that
-        case, which is consistent with AC-007 ("fields available from the
-        realtime path").
-
-        The public ``call_llm_async`` contract (returns ``str``) is unchanged.
-        """
-        if routing_context is not None and self.routing_service:
-            # Routing path: we cannot expose the raw response without invasive
-            # surgery on the routing stack. Return (text, None); usage will be
-            # absent, which is correct — routing is not the realtime direct path.
-            text = await self._call_llm_async_core(
-                messages, provider, model, temperature, routing_context, **kwargs
-            )
-            return text, None
-        if not provider:
-            raise LLMServiceError(
-                "provider is required when routing_context is not provided."
-            )
-        return await self._call_llm_async_direct_with_response(
-            provider, messages, model, temperature, **kwargs
-        )
 
     async def _invoke_provider_async(
         self, client: Any, langchain_messages: List[Any]
@@ -1494,7 +1339,8 @@ class LLMService:
         """Async convenience wrapper mirroring ``ask()`` behavior."""
         provider = provider or "anthropic"
         messages = [{"role": "user", "content": prompt}]
-        return await self.call_llm_async(provider=provider, messages=messages, **kwargs)
+        response = await self.call_llm_async(provider=provider, messages=messages, **kwargs)
+        return response.text
 
     async def call_llm_many_async(
         self,
@@ -1533,12 +1379,17 @@ class LLMService:
             raise LLMServiceError(
                 "call_specs must not be empty — at least one LLMCallSpec is required."
             )
-        if not isinstance(max_concurrency, int) or max_concurrency < 1:
+        # Reject bool explicitly: isinstance(True, int) is True in Python.
+        if isinstance(max_concurrency, bool) or not isinstance(max_concurrency, int) or max_concurrency < 1:
             raise LLMServiceError(
                 f"max_concurrency must be an integer >= 1, got {max_concurrency!r}."
             )
         seen_ids: set = set()
         for spec in call_specs:
+            if not isinstance(spec.spec_id, str) or not spec.spec_id:
+                raise LLMServiceError(
+                    f"spec_id must be a non-empty string, got {spec.spec_id!r}."
+                )
             if spec.spec_id in seen_ids:
                 raise LLMServiceError(
                     f"Duplicate spec_id detected: {spec.spec_id!r}. "
@@ -1551,11 +1402,19 @@ class LLMService:
         spec: LLMCallSpec,
         semaphore: asyncio.Semaphore,
     ) -> LLMCallResult:
-        """Execute one fan-out item through the existing async realtime path."""
+        """Execute one fan-out item through the public ``call_llm_async`` path.
+
+        Calls ``call_llm_async`` directly so that routing, retry, jitter,
+        circuit-breaker, fallback, telemetry, and cache-aware behavior are all
+        inherited from the single async resilience stack (spec Decision 3).
+        Builds ``LLMCallResult`` from the returned ``LLMResponse`` so that
+        ``provider``, ``model``, and ``usage`` reflect the resolved values, not
+        the requested spec values.
+        """
         async with semaphore:
             kwargs = dict(spec.request_options)
             try:
-                response_text, raw_response = await self._call_llm_async_with_response(
+                llm_response = await self.call_llm_async(
                     messages=spec.messages,
                     provider=spec.provider,
                     model=spec.model,
@@ -1563,18 +1422,13 @@ class LLMService:
                     routing_context=spec.routing_context,
                     **kwargs,
                 )
-                usage = (
-                    self._extract_llm_usage(raw_response)
-                    if raw_response is not None
-                    else None
-                )
                 return LLMCallResult(
                     spec_id=spec.spec_id,
                     status="succeeded",
-                    provider=spec.provider,
-                    model=spec.model,
-                    content=response_text,
-                    usage=usage,
+                    provider=llm_response.resolved_provider,
+                    model=llm_response.resolved_model,
+                    content=llm_response.text,
+                    usage=llm_response.usage,
                 )
             except Exception as exc:
                 return LLMCallResult(
@@ -1586,7 +1440,7 @@ class LLMService:
                     usage=None,
                     error=LLMExecutionError(
                         error_type=type(exc).__name__,
-                        message=str(exc),
+                        message=_sanitize_error_message(exc),
                         retryable=is_retryable(exc),
                     ),
                 )
@@ -1595,9 +1449,11 @@ class LLMService:
     def _extract_llm_usage(response: Any) -> Optional[LLMUsage]:
         """Extract a normalized ``LLMUsage`` from an LLM provider response.
 
-        Returns ``None`` when no usage metadata is available.  This is the
-        richer sibling of ``_extract_token_counts()`` that also captures
-        cache-aware fields introduced by E05-F01.
+        Returns ``None`` when no usage metadata is available or when
+        ``usage_metadata`` is present but all fields fail coercion.  Per-field
+        coercion failures return ``None`` for that field (not for the whole
+        ``LLMUsage``) so that a malformed token count never converts a successful
+        provider response into a failed ``LLMCallResult``.
         """
         usage_metadata = getattr(response, "usage_metadata", None)
         if not usage_metadata:
@@ -1608,7 +1464,12 @@ class LLMService:
                 val = usage_metadata.get(key)
             else:
                 val = getattr(usage_metadata, key, None)
-            return int(val) if val is not None else None
+            if val is None:
+                return None
+            try:
+                return int(val)
+            except (TypeError, ValueError):
+                return None
 
         return LLMUsage(
             input_tokens=_get("input_tokens"),

--- a/src/agentmap/services/llm_service.py
+++ b/src/agentmap/services/llm_service.py
@@ -783,11 +783,18 @@ class LLMService:
                 **kwargs,
             )
 
+        except LLMResolvedCallError:
+            # Post-selection provider failure — routing already resolved a concrete
+            # (provider, model) before the call failed. Preserve that identity
+            # intact; do NOT trigger the routing-fallback retry path, which would
+            # silently rewrite the resolved identity with the fallback provider.
+            # Mirrors the identical guard in _call_llm_async_direct:842.
+            raise
         except Exception as e:
             self._logger.error(f"Routing failed: {e}")
             fallback_provider = routing_context.get("fallback_provider", "anthropic")
             self._logger.warning(
-                f"Falling back to {fallback_provider} due to routing failure"
+                f"Falling back to {fallback_provider} due to pre-selection routing failure"
             )
             self._record_fallback_metric("routing_fallback")
             fallback_max_tokens = routing_context.get("max_tokens")
@@ -829,7 +836,7 @@ class LLMService:
             elif max_tokens is not None:
                 config["max_tokens"] = max_tokens
 
-        current_model = config.get("model", "unknown")
+        current_model = config.get("model")
 
         try:
             client = self._client_factory.get_or_create_client(provider, config)

--- a/src/agentmap/services/llm_service.py
+++ b/src/agentmap/services/llm_service.py
@@ -77,6 +77,13 @@ from agentmap.services.telemetry.constants import (
     ROUTING_PROVIDER,
 )
 
+# Keys that ``call_llm_async`` accepts as explicit parameters.  If any of these
+# appear in ``LLMCallSpec.request_options`` they would collide with the explicit
+# keyword arguments in ``_execute_fan_out_item``, causing a TypeError at runtime.
+_RESERVED_KEYS: frozenset = frozenset(
+    {"messages", "provider", "model", "temperature", "routing_context"}
+)
+
 
 class LLMService:
     """
@@ -821,24 +828,24 @@ class LLMService:
         Returns ``LLMResponse`` carrying the resolved provider, model, and usage
         extracted from the raw provider response.
         """
-        provider = self._provider_utils.normalize_provider(provider)
-        config = self._provider_utils.get_provider_config(provider)
-
-        max_tokens = kwargs.pop("max_tokens", None)
-        if model or temperature is not None or max_tokens is not None:
-            config = config.copy()
-            if model:
-                config["model"] = model
-            if temperature is not None:
-                config["temperature"] = temperature
-            if max_tokens == 0:
-                config.pop("max_tokens", None)
-            elif max_tokens is not None:
-                config["max_tokens"] = max_tokens
-
-        current_model = config.get("model")
-
+        current_model = None
         try:
+            provider = self._provider_utils.normalize_provider(provider)
+            config = self._provider_utils.get_provider_config(provider)
+
+            max_tokens = kwargs.pop("max_tokens", None)
+            if model or temperature is not None or max_tokens is not None:
+                config = config.copy()
+                if model:
+                    config["model"] = model
+                if temperature is not None:
+                    config["temperature"] = temperature
+                if max_tokens == 0:
+                    config.pop("max_tokens", None)
+                elif max_tokens is not None:
+                    config["max_tokens"] = max_tokens
+
+            current_model = config.get("model")
             client = self._client_factory.get_or_create_client(provider, config)
             langchain_messages = self._message_utils.convert_messages_to_langchain(
                 messages
@@ -1102,6 +1109,7 @@ class LLMService:
             response = async_invoke(langchain_messages)
             if inspect.isawaitable(response):
                 return await response
+            return response
         return await asyncio.to_thread(client.invoke, langchain_messages)
 
     # ------------------------------------------------------------------
@@ -1424,6 +1432,13 @@ class LLMService:
                     "Each spec_id must be unique within one submission."
                 )
             seen_ids.add(spec.spec_id)
+            if spec.request_options:
+                collision = _RESERVED_KEYS & spec.request_options.keys()
+                if collision:
+                    raise ValueError(
+                        f"spec_id={spec.spec_id!r}: request_options contains reserved "
+                        f"keys that collide with call_llm_async parameters: {collision}"
+                    )
 
     async def _execute_fan_out_item(
         self,

--- a/src/agentmap/services/llm_service.py
+++ b/src/agentmap/services/llm_service.py
@@ -18,6 +18,7 @@ from agentmap.exceptions import (
     LLMConfigurationError,
     LLMDependencyError,
     LLMProviderError,
+    LLMResolvedCallError,
     LLMServiceError,
 )
 from agentmap.models.llm_execution import (
@@ -838,11 +839,16 @@ class LLMService:
             return await self._invoke_with_resilience_async(
                 client, langchain_messages, provider, current_model
             )
+        except LLMResolvedCallError:
+            # Already wrapped by the fallback handler — preserve its tier identity.
+            raise
         except Exception as e:
             typed_error = classify_llm_error(e, provider)
 
             if isinstance(typed_error, (LLMDependencyError, LLMConfigurationError)):
-                raise typed_error
+                raise LLMResolvedCallError(
+                    provider, current_model, typed_error
+                ) from typed_error
 
             if self.features_registry and self.routing_config:
                 try:
@@ -856,10 +862,19 @@ class LLMService:
                         self._message_utils.convert_messages_to_langchain,
                         **kwargs,
                     )
-                except LLMServiceError:
-                    pass
+                except LLMResolvedCallError:
+                    # Fallback handler already wrapped the error with tier identity.
+                    raise
+                except LLMServiceError as fallback_err:
+                    # Tier exhaustion without LLMResolvedCallError — wrap with
+                    # the original provider/model (the last known resolved identity).
+                    raise LLMResolvedCallError(
+                        provider, current_model, fallback_err
+                    ) from fallback_err
 
-            raise typed_error
+            raise LLMResolvedCallError(
+                provider, current_model, typed_error
+            ) from typed_error
 
     def _invoke_with_resilience(
         self,
@@ -1339,7 +1354,9 @@ class LLMService:
         """Async convenience wrapper mirroring ``ask()`` behavior."""
         provider = provider or "anthropic"
         messages = [{"role": "user", "content": prompt}]
-        response = await self.call_llm_async(provider=provider, messages=messages, **kwargs)
+        response = await self.call_llm_async(
+            provider=provider, messages=messages, **kwargs
+        )
         return response.text
 
     async def call_llm_many_async(
@@ -1380,7 +1397,11 @@ class LLMService:
                 "call_specs must not be empty — at least one LLMCallSpec is required."
             )
         # Reject bool explicitly: isinstance(True, int) is True in Python.
-        if isinstance(max_concurrency, bool) or not isinstance(max_concurrency, int) or max_concurrency < 1:
+        if (
+            isinstance(max_concurrency, bool)
+            or not isinstance(max_concurrency, int)
+            or max_concurrency < 1
+        ):
             raise LLMServiceError(
                 f"max_concurrency must be an integer >= 1, got {max_concurrency!r}."
             )
@@ -1430,7 +1451,26 @@ class LLMService:
                     content=llm_response.text,
                     usage=llm_response.usage,
                 )
+            except LLMResolvedCallError as exc:
+                # Failure occurred after routing/fallback resolved a concrete
+                # provider/model — preserve that identity in the result record.
+                return LLMCallResult(
+                    spec_id=spec.spec_id,
+                    status="failed",
+                    provider=exc.resolved_provider,
+                    model=exc.resolved_model,
+                    content=None,
+                    usage=None,
+                    error=LLMExecutionError(
+                        error_type=type(exc.cause).__name__,
+                        message=_sanitize_error_message(exc.cause),
+                        retryable=is_retryable(exc.cause),
+                    ),
+                )
             except Exception as exc:
+                # Failure occurred before any provider/model was resolved
+                # (e.g., validation error, routing service unavailable).
+                # Echo spec values — may be None. Do not fabricate.
                 return LLMCallResult(
                     spec_id=spec.spec_id,
                     status="failed",

--- a/src/agentmap/services/llm_service.py
+++ b/src/agentmap/services/llm_service.py
@@ -6,7 +6,9 @@ handling configuration, error handling, provider abstraction, tiered fallback,
 and resilience (retry with backoff + circuit breaker).
 """
 
+import asyncio
 import base64
+import inspect
 import mimetypes
 import random
 import time
@@ -17,6 +19,12 @@ from agentmap.exceptions import (
     LLMDependencyError,
     LLMProviderError,
     LLMServiceError,
+)
+from agentmap.models.llm_execution import (
+    LLMCallResult,
+    LLMCallSpec,
+    LLMExecutionError,
+    LLMUsage,
 )
 from agentmap.services.config import AppConfigService
 from agentmap.services.config.llm_models_config_service import LLMModelsConfigService
@@ -113,6 +121,7 @@ class LLMService:
             routing_config_service,
             features_registry_service,
             invoke_fn=self._invoke_with_resilience,
+            invoke_async_fn=self._invoke_with_resilience_async,
         )
         self._message_utils = LLMMessageUtils()
 
@@ -252,6 +261,86 @@ class LLMService:
             messages, provider, model, temperature, routing_context, **kwargs
         )
 
+    async def call_llm_async(
+        self,
+        messages: List[Dict[str, str]],
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        routing_context: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Make an async LLM call with the same public contract as ``call_llm()``.
+
+        When routing_context is provided, routing owns all provider and model
+        selection. Explicit provider and model inputs are ignored with the same
+        warnings used by the sync path.
+        """
+        if self._telemetry_service is not None:
+            return await self._call_llm_async_with_telemetry(
+                messages, provider, model, temperature, routing_context, **kwargs
+            )
+        return await self._call_llm_async_core(
+            messages, provider, model, temperature, routing_context, **kwargs
+        )
+
+    async def _call_llm_async_with_telemetry(
+        self,
+        messages: List[Dict[str, str]],
+        provider: Optional[str],
+        model: Optional[str],
+        temperature: Optional[float],
+        routing_context: Optional[Dict[str, Any]],
+        **kwargs,
+    ) -> str:
+        """Async telemetry wrapper mirroring the sync LLM span behavior."""
+        initial_attributes: Dict[str, Any] = {}
+        if provider:
+            initial_attributes[GEN_AI_SYSTEM] = self._provider_utils.normalize_provider(
+                provider
+            )
+        if model:
+            initial_attributes[GEN_AI_REQUEST_MODEL] = model
+
+        try:
+            with self._telemetry_service.start_span(
+                LLM_CALL_SPAN,
+                attributes=initial_attributes,
+            ) as span:
+                try:
+                    result = await self._call_llm_async_core(
+                        messages,
+                        provider,
+                        model,
+                        temperature,
+                        routing_context,
+                        **kwargs,
+                    )
+                    self._capture_llm_content(span, messages, result)
+                    self._set_span_status_ok(span)
+                    return result
+                except Exception as e:
+                    self._record_span_exception_safe(span, e)
+                    raise
+        except Exception as outer_error:
+            if isinstance(
+                outer_error,
+                (
+                    LLMServiceError,
+                    LLMProviderError,
+                    LLMConfigurationError,
+                    LLMDependencyError,
+                ),
+            ):
+                raise
+            self._logger.warning(
+                f"Telemetry error, executing without instrumentation: {outer_error}"
+            )
+            return await self._call_llm_async_core(
+                messages, provider, model, temperature, routing_context, **kwargs
+            )
+
     def _call_llm_with_telemetry(
         self,
         messages: List[Dict[str, str]],
@@ -358,6 +447,45 @@ class LLMService:
                 "provider is required when routing_context is not provided."
             )
         return self._call_llm_direct(
+            provider,
+            messages,
+            model,
+            temperature,
+            **kwargs,
+        )
+
+    async def _call_llm_async_core(
+        self,
+        messages: List[Dict[str, str]],
+        provider: Optional[str],
+        model: Optional[str],
+        temperature: Optional[float],
+        routing_context: Optional[Dict[str, Any]],
+        **kwargs,
+    ) -> str:
+        """Async sibling of ``_call_llm_core`` for the staged migration."""
+        if routing_context is not None and self.routing_service:
+            if model is not None:
+                self._logger.warning(
+                    "[LLMService] 'model' parameter is ignored when routing_context "
+                    "is provided. Use routing_context['model_override'] to force a "
+                    "specific model."
+                )
+            if provider is not None:
+                self._logger.warning(
+                    "[LLMService] 'provider' parameter is ignored when routing_context "
+                    "is provided. Use routing_context['provider_preference'] to "
+                    "influence provider selection or "
+                    "routing_context['fallback_provider'] to set the fallback."
+                )
+            return await self._call_llm_async_with_routing(
+                messages, routing_context, **kwargs
+            )
+        if not provider:
+            raise LLMServiceError(
+                "provider is required when routing_context is not provided."
+            )
+        return await self._call_llm_async_direct(
             provider,
             messages,
             model,
@@ -565,6 +693,146 @@ class LLMService:
 
             raise typed_error
 
+    async def _call_llm_async_with_routing(
+        self, messages: List[Dict[str, str]], routing_context: Dict[str, Any], **kwargs
+    ) -> str:
+        """Async sibling of ``_call_llm_with_routing`` preserving routing rules."""
+        if not self.routing_service:
+            raise LLMServiceError("Routing requested but no routing service available")
+
+        try:
+            context = self._create_routing_context(routing_context, messages)
+            available_providers = self._provider_utils.get_available_providers()
+
+            if not available_providers:
+                raise LLMServiceError("No providers configured")
+
+            prompt = self._message_utils.extract_prompt_from_messages(messages)
+            decision = self.routing_service.route_request(
+                prompt=prompt,
+                task_type=context.task_type,
+                available_providers=available_providers,
+                routing_context=context,
+            )
+
+            self._logger.info(
+                f"Routing decision: {decision.provider}:{decision.model} "
+                f"(complexity: {decision.complexity}, "
+                f"confidence: {decision.confidence:.2f})"
+            )
+
+            self._record_routing_attributes(decision)
+
+            node_max_tokens = routing_context.get("max_tokens")
+            if node_max_tokens is None:
+                node_max_tokens = kwargs.pop("max_tokens", None)
+
+            resolved_max_tokens = (
+                node_max_tokens if node_max_tokens is not None else decision.max_tokens
+            )
+            if resolved_max_tokens == 0:
+                self._logger.debug(
+                    "max_tokens=0 resolved to no limit (provider default)"
+                )
+                kwargs["max_tokens"] = 0
+                resolved_max_tokens = None
+            elif resolved_max_tokens is not None:
+                source = (
+                    "node context" if node_max_tokens is not None else "activity config"
+                )
+                self._logger.debug(
+                    f"max_tokens={resolved_max_tokens} (source: {source})"
+                )
+                kwargs["max_tokens"] = resolved_max_tokens
+
+            if resolved_max_tokens is not None:
+                self._set_current_span_attributes(
+                    {GEN_AI_REQUEST_MAX_TOKENS: resolved_max_tokens}
+                )
+
+            return await self._call_llm_async_direct(
+                provider=decision.provider,
+                messages=messages,
+                model=decision.model,
+                temperature=kwargs.get("temperature"),
+                **kwargs,
+            )
+
+        except Exception as e:
+            self._logger.error(f"Routing failed: {e}")
+            fallback_provider = routing_context.get("fallback_provider", "anthropic")
+            self._logger.warning(
+                f"Falling back to {fallback_provider} due to routing failure"
+            )
+            self._record_fallback_metric("routing_fallback")
+            fallback_max_tokens = routing_context.get("max_tokens")
+            if fallback_max_tokens is not None and "max_tokens" not in kwargs:
+                kwargs["max_tokens"] = fallback_max_tokens
+            return await self._call_llm_async_direct(
+                provider=fallback_provider,
+                messages=messages,
+                model=kwargs.get("model"),
+                temperature=kwargs.get("temperature"),
+                **kwargs,
+            )
+
+    async def _call_llm_async_direct(
+        self,
+        provider: str,
+        messages: List[Dict[str, str]],
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        **kwargs,
+    ) -> str:
+        """Async direct provider invocation with resilience and fallback parity."""
+        provider = self._provider_utils.normalize_provider(provider)
+        config = self._provider_utils.get_provider_config(provider)
+
+        max_tokens = kwargs.pop("max_tokens", None)
+        if model or temperature is not None or max_tokens is not None:
+            config = config.copy()
+            if model:
+                config["model"] = model
+            if temperature is not None:
+                config["temperature"] = temperature
+            if max_tokens == 0:
+                config.pop("max_tokens", None)
+            elif max_tokens is not None:
+                config["max_tokens"] = max_tokens
+
+        current_model = config.get("model", "unknown")
+
+        try:
+            client = self._client_factory.get_or_create_client(provider, config)
+            langchain_messages = self._message_utils.convert_messages_to_langchain(
+                messages
+            )
+            return await self._invoke_with_resilience_async(
+                client, langchain_messages, provider, current_model
+            )
+        except Exception as e:
+            typed_error = classify_llm_error(e, provider)
+
+            if isinstance(typed_error, (LLMDependencyError, LLMConfigurationError)):
+                raise typed_error
+
+            if self.features_registry and self.routing_config:
+                try:
+                    return await self._fallback_handler.try_with_fallback_async(
+                        provider,
+                        current_model,
+                        messages,
+                        typed_error,
+                        self._provider_utils.get_provider_config,
+                        self._client_factory.get_or_create_client,
+                        self._message_utils.convert_messages_to_langchain,
+                        **kwargs,
+                    )
+                except LLMServiceError:
+                    pass
+
+            raise typed_error
+
     def _invoke_with_resilience(
         self,
         client: Any,
@@ -678,6 +946,102 @@ class LLMService:
         self._record_error_metric(last_error, provider, model)
         self._record_circuit_breaker_metric_on_open(provider, model)
         raise last_error  # type: ignore[misc]
+
+    async def _invoke_with_resilience_async(
+        self,
+        client: Any,
+        langchain_messages: List[Any],
+        provider: str,
+        model: str,
+    ) -> str:
+        """Async sibling of ``_invoke_with_resilience`` using awaited backoff."""
+        self._record_circuit_breaker_state(provider, model)
+
+        if self._circuit_breaker.is_open(provider, model):
+            raise LLMProviderError(
+                f"Circuit breaker open for {provider}:{model} -- "
+                f"skipping call (resets after "
+                f"{self._circuit_breaker.reset}s)"
+            )
+
+        retry_cfg = self._resilience_config.get("retry", {})
+        max_attempts = retry_cfg.get("max_attempts", 3)
+        backoff_base = retry_cfg.get("backoff_base", 2.0)
+        backoff_max = retry_cfg.get("backoff_max", 30.0)
+        jitter = retry_cfg.get("jitter", True)
+
+        last_error: Optional[Exception] = None
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                self._logger.debug(
+                    f"LLM call to {provider}:{model} "
+                    f"(attempt {attempt}/{max_attempts})"
+                )
+                start_time = time.monotonic()
+                response = await self._invoke_provider_async(client, langchain_messages)
+                duration = time.monotonic() - start_time
+
+                result = (
+                    response.content if hasattr(response, "content") else str(response)
+                )
+
+                was_open = self._circuit_breaker.is_open(provider, model)
+                self._circuit_breaker.record_success(provider, model)
+                self._record_circuit_breaker_metric_on_close(was_open, provider, model)
+                self._record_duration_metric(duration, provider, model)
+                self._record_llm_response_attributes(response, provider, model)
+
+                resp_meta = getattr(response, "response_metadata", None)
+                req_id = (
+                    self._extract_provider_request_id(resp_meta, provider)
+                    if isinstance(resp_meta, dict)
+                    else None
+                )
+                self._logger.debug(
+                    f"LLM call successful, response length: {len(result)}"
+                    + (f", request_id: {req_id}" if req_id else "")
+                )
+                return result
+            except Exception as e:
+                typed_error = classify_llm_error(e, provider)
+                last_error = typed_error
+
+                if not is_retryable(typed_error):
+                    self._circuit_breaker.record_failure(provider, model)
+                    self._record_error_metric(typed_error, provider, model)
+                    self._record_circuit_breaker_metric_on_open(provider, model)
+                    raise typed_error
+
+                if attempt == max_attempts:
+                    break
+
+                delay = min(backoff_base ** (attempt - 1), backoff_max)
+                if jitter:
+                    delay = delay * (0.5 + random.random())
+
+                self._logger.warning(
+                    f"Retryable error on {provider}:{model} "
+                    f"(attempt {attempt}/{max_attempts}): {typed_error}. "
+                    f"Retrying in {delay:.1f}s"
+                )
+                await asyncio.sleep(delay)
+
+        self._circuit_breaker.record_failure(provider, model)
+        self._record_error_metric(last_error, provider, model)
+        self._record_circuit_breaker_metric_on_open(provider, model)
+        raise last_error  # type: ignore[misc]
+
+    async def _invoke_provider_async(
+        self, client: Any, langchain_messages: List[Any]
+    ) -> Any:
+        """Invoke the provider client with native async or worker-thread fallback."""
+        async_invoke = getattr(client, "ainvoke", None)
+        if callable(async_invoke):
+            response = async_invoke(langchain_messages)
+            if inspect.isawaitable(response):
+                return await response
+        return await asyncio.to_thread(client.invoke, langchain_messages)
 
     # ------------------------------------------------------------------
     # Routing telemetry helpers (error-isolated, silent no-op when disabled)
@@ -929,6 +1293,135 @@ class LLMService:
         provider = provider or "anthropic"
         messages = [{"role": "user", "content": prompt}]
         return self.call_llm(provider=provider, messages=messages, **kwargs)
+
+    async def ask_async(
+        self, prompt: str, provider: Optional[str] = None, **kwargs
+    ) -> str:
+        """Async convenience wrapper mirroring ``ask()`` behavior."""
+        provider = provider or "anthropic"
+        messages = [{"role": "user", "content": prompt}]
+        return await self.call_llm_async(provider=provider, messages=messages, **kwargs)
+
+    async def call_llm_many_async(
+        self,
+        call_specs: List[LLMCallSpec],
+        max_concurrency: int,
+    ) -> List[LLMCallResult]:
+        """
+        Submit many LLM call specs and receive one terminal result per spec.
+
+        Validates the submission before any provider execution:
+        - ``call_specs`` must not be empty.
+        - ``spec_id`` values must be unique within one submission.
+        - ``max_concurrency`` must be an integer >= 1.
+
+        Once execution starts, item failures are captured as ``LLMCallResult``
+        records with ``status="failed"`` rather than aborting the submission.
+        The returned list preserves the same positional order as ``call_specs``.
+        """
+        self._validate_fan_out_submission(call_specs, max_concurrency)
+
+        semaphore = asyncio.Semaphore(max_concurrency)
+        tasks = [
+            asyncio.ensure_future(self._execute_fan_out_item(spec, semaphore))
+            for spec in call_specs
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=False)
+        return list(results)
+
+    def _validate_fan_out_submission(
+        self,
+        call_specs: List[LLMCallSpec],
+        max_concurrency: int,
+    ) -> None:
+        """Validate a fan-out submission before any provider execution begins."""
+        if not call_specs:
+            raise LLMServiceError(
+                "call_specs must not be empty — at least one LLMCallSpec is required."
+            )
+        if not isinstance(max_concurrency, int) or max_concurrency < 1:
+            raise LLMServiceError(
+                f"max_concurrency must be an integer >= 1, got {max_concurrency!r}."
+            )
+        seen_ids: set = set()
+        for spec in call_specs:
+            if spec.spec_id in seen_ids:
+                raise LLMServiceError(
+                    f"Duplicate spec_id detected: {spec.spec_id!r}. "
+                    "Each spec_id must be unique within one submission."
+                )
+            seen_ids.add(spec.spec_id)
+
+    async def _execute_fan_out_item(
+        self,
+        spec: LLMCallSpec,
+        semaphore: asyncio.Semaphore,
+    ) -> LLMCallResult:
+        """Execute one fan-out item through the existing async realtime path."""
+        async with semaphore:
+            kwargs = dict(spec.request_options)
+            try:
+                response_text = await self.call_llm_async(
+                    messages=spec.messages,
+                    provider=spec.provider,
+                    model=spec.model,
+                    temperature=spec.temperature,
+                    routing_context=spec.routing_context,
+                    **kwargs,
+                )
+                # call_llm_async returns a str; usage metadata must be extracted
+                # from the raw response. We capture it separately via a lower
+                # seam when available; otherwise usage fields remain None.
+                return LLMCallResult(
+                    spec_id=spec.spec_id,
+                    status="succeeded",
+                    provider=spec.provider,
+                    model=spec.model,
+                    content=response_text,
+                    usage=None,
+                )
+            except Exception as exc:
+                from agentmap.services.llm_error_utils import is_retryable
+
+                return LLMCallResult(
+                    spec_id=spec.spec_id,
+                    status="failed",
+                    provider=spec.provider,
+                    model=spec.model,
+                    content=None,
+                    usage=None,
+                    error=LLMExecutionError(
+                        error_type=type(exc).__name__,
+                        message=str(exc),
+                        retryable=is_retryable(exc),
+                    ),
+                )
+
+    @staticmethod
+    def _extract_llm_usage(response: Any) -> Optional[LLMUsage]:
+        """Extract a normalized ``LLMUsage`` from an LLM provider response.
+
+        Returns ``None`` when no usage metadata is available.  This is the
+        richer sibling of ``_extract_token_counts()`` that also captures
+        cache-aware fields introduced by E05-F01.
+        """
+        usage_metadata = getattr(response, "usage_metadata", None)
+        if not usage_metadata:
+            return None
+
+        def _get(key: str) -> Optional[int]:
+            if isinstance(usage_metadata, dict):
+                val = usage_metadata.get(key)
+            else:
+                val = getattr(usage_metadata, key, None)
+            return int(val) if val is not None else None
+
+        return LLMUsage(
+            input_tokens=_get("input_tokens"),
+            output_tokens=_get("output_tokens"),
+            cache_creation_input_tokens=_get("cache_creation_input_tokens"),
+            cache_read_input_tokens=_get("cache_read_input_tokens"),
+        )
 
     def get_available_providers(self) -> List[str]:
         """

--- a/src/agentmap/services/llm_service.py
+++ b/src/agentmap/services/llm_service.py
@@ -1032,6 +1032,200 @@ class LLMService:
         self._record_circuit_breaker_metric_on_open(provider, model)
         raise last_error  # type: ignore[misc]
 
+    async def _invoke_with_resilience_async_with_response(
+        self,
+        client: Any,
+        langchain_messages: List[Any],
+        provider: str,
+        model: str,
+    ) -> Tuple[str, Any]:
+        """Async resilience wrapper that also returns the raw provider response.
+
+        This is the lower seam used by the fan-out path so that per-item usage
+        metadata (``usage_metadata``) is preserved alongside the text result.
+        It mirrors ``_invoke_with_resilience_async`` exactly except it returns
+        ``(text, raw_response)`` instead of just ``text``.
+        """
+        self._record_circuit_breaker_state(provider, model)
+
+        if self._circuit_breaker.is_open(provider, model):
+            raise LLMProviderError(
+                f"Circuit breaker open for {provider}:{model} -- "
+                f"skipping call (resets after "
+                f"{self._circuit_breaker.reset}s)"
+            )
+
+        retry_cfg = self._resilience_config.get("retry", {})
+        max_attempts = retry_cfg.get("max_attempts", 3)
+        backoff_base = retry_cfg.get("backoff_base", 2.0)
+        backoff_max = retry_cfg.get("backoff_max", 30.0)
+        jitter = retry_cfg.get("jitter", True)
+
+        last_error: Optional[Exception] = None
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                self._logger.debug(
+                    f"LLM call to {provider}:{model} "
+                    f"(attempt {attempt}/{max_attempts})"
+                )
+                start_time = time.monotonic()
+                response = await self._invoke_provider_async(client, langchain_messages)
+                duration = time.monotonic() - start_time
+
+                result = (
+                    response.content if hasattr(response, "content") else str(response)
+                )
+
+                was_open = self._circuit_breaker.is_open(provider, model)
+                self._circuit_breaker.record_success(provider, model)
+                self._record_circuit_breaker_metric_on_close(was_open, provider, model)
+                self._record_duration_metric(duration, provider, model)
+                self._record_llm_response_attributes(response, provider, model)
+
+                resp_meta = getattr(response, "response_metadata", None)
+                req_id = (
+                    self._extract_provider_request_id(resp_meta, provider)
+                    if isinstance(resp_meta, dict)
+                    else None
+                )
+                self._logger.debug(
+                    f"LLM call successful, response length: {len(result)}"
+                    + (f", request_id: {req_id}" if req_id else "")
+                )
+                return result, response
+            except Exception as e:
+                typed_error = classify_llm_error(e, provider)
+                last_error = typed_error
+
+                if not is_retryable(typed_error):
+                    self._circuit_breaker.record_failure(provider, model)
+                    self._record_error_metric(typed_error, provider, model)
+                    self._record_circuit_breaker_metric_on_open(provider, model)
+                    raise typed_error
+
+                if attempt == max_attempts:
+                    break
+
+                delay = min(backoff_base ** (attempt - 1), backoff_max)
+                if jitter:
+                    delay = delay * (0.5 + random.random())
+
+                self._logger.warning(
+                    f"Retryable error on {provider}:{model} "
+                    f"(attempt {attempt}/{max_attempts}): {typed_error}. "
+                    f"Retrying in {delay:.1f}s"
+                )
+                await asyncio.sleep(delay)
+
+        self._circuit_breaker.record_failure(provider, model)
+        self._record_error_metric(last_error, provider, model)
+        self._record_circuit_breaker_metric_on_open(provider, model)
+        raise last_error  # type: ignore[misc]
+
+    async def _call_llm_async_direct_with_response(
+        self,
+        provider: str,
+        messages: List[Dict[str, str]],
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        **kwargs,
+    ) -> Tuple[str, Any]:
+        """Variant of ``_call_llm_async_direct`` returning ``(text, raw_response)``.
+
+        Used by the fan-out path so that ``usage_metadata`` on the raw response
+        object survives into ``_execute_fan_out_item`` for normalization into
+        ``LLMCallResult.usage``.  The public ``call_llm_async`` contract (returns
+        ``str``) is unchanged.
+        """
+        provider = self._provider_utils.normalize_provider(provider)
+        config = self._provider_utils.get_provider_config(provider)
+
+        max_tokens = kwargs.pop("max_tokens", None)
+        if model or temperature is not None or max_tokens is not None:
+            config = config.copy()
+            if model:
+                config["model"] = model
+            if temperature is not None:
+                config["temperature"] = temperature
+            if max_tokens == 0:
+                config.pop("max_tokens", None)
+            elif max_tokens is not None:
+                config["max_tokens"] = max_tokens
+
+        current_model = config.get("model", "unknown")
+
+        try:
+            client = self._client_factory.get_or_create_client(provider, config)
+            langchain_messages = self._message_utils.convert_messages_to_langchain(
+                messages
+            )
+            return await self._invoke_with_resilience_async_with_response(
+                client, langchain_messages, provider, current_model
+            )
+        except Exception as e:
+            typed_error = classify_llm_error(e, provider)
+
+            if isinstance(typed_error, (LLMDependencyError, LLMConfigurationError)):
+                raise typed_error
+
+            if self.features_registry and self.routing_config:
+                try:
+                    # Fallback path returns str only; return (text, None) since
+                    # the raw response is not accessible through the fallback seam.
+                    fallback_text = (
+                        await self._fallback_handler.try_with_fallback_async(
+                            provider,
+                            current_model,
+                            messages,
+                            typed_error,
+                            self._provider_utils.get_provider_config,
+                            self._client_factory.get_or_create_client,
+                            self._message_utils.convert_messages_to_langchain,
+                            **kwargs,
+                        )
+                    )
+                    return fallback_text, None
+                except LLMServiceError:
+                    pass
+
+            raise typed_error
+
+    async def _call_llm_async_with_response(
+        self,
+        messages: List[Dict[str, str]],
+        provider: Optional[str],
+        model: Optional[str],
+        temperature: Optional[float],
+        routing_context: Optional[Dict[str, Any]],
+        **kwargs,
+    ) -> Tuple[str, Any]:
+        """Internal seam for fan-out: returns ``(text, raw_response)``.
+
+        When ``routing_context`` is active, the raw response is not available
+        through the routing stack so ``raw_response`` will be ``None``.  The
+        fan-out caller must tolerate ``None`` and produce ``usage=None`` in that
+        case, which is consistent with AC-007 ("fields available from the
+        realtime path").
+
+        The public ``call_llm_async`` contract (returns ``str``) is unchanged.
+        """
+        if routing_context is not None and self.routing_service:
+            # Routing path: we cannot expose the raw response without invasive
+            # surgery on the routing stack. Return (text, None); usage will be
+            # absent, which is correct — routing is not the realtime direct path.
+            text = await self._call_llm_async_core(
+                messages, provider, model, temperature, routing_context, **kwargs
+            )
+            return text, None
+        if not provider:
+            raise LLMServiceError(
+                "provider is required when routing_context is not provided."
+            )
+        return await self._call_llm_async_direct_with_response(
+            provider, messages, model, temperature, **kwargs
+        )
+
     async def _invoke_provider_async(
         self, client: Any, langchain_messages: List[Any]
     ) -> Any:
@@ -1361,7 +1555,7 @@ class LLMService:
         async with semaphore:
             kwargs = dict(spec.request_options)
             try:
-                response_text = await self.call_llm_async(
+                response_text, raw_response = await self._call_llm_async_with_response(
                     messages=spec.messages,
                     provider=spec.provider,
                     model=spec.model,
@@ -1369,20 +1563,20 @@ class LLMService:
                     routing_context=spec.routing_context,
                     **kwargs,
                 )
-                # call_llm_async returns a str; usage metadata must be extracted
-                # from the raw response. We capture it separately via a lower
-                # seam when available; otherwise usage fields remain None.
+                usage = (
+                    self._extract_llm_usage(raw_response)
+                    if raw_response is not None
+                    else None
+                )
                 return LLMCallResult(
                     spec_id=spec.spec_id,
                     status="succeeded",
                     provider=spec.provider,
                     model=spec.model,
                     content=response_text,
-                    usage=None,
+                    usage=usage,
                 )
             except Exception as exc:
-                from agentmap.services.llm_error_utils import is_retryable
-
                 return LLMCallResult(
                     spec_id=spec.spec_id,
                     status="failed",

--- a/src/agentmap/services/llm_service.py
+++ b/src/agentmap/services/llm_service.py
@@ -464,7 +464,9 @@ class LLMService:
                     "influence provider selection or "
                     "routing_context['fallback_provider'] to set the fallback."
                 )
-            return self._call_llm_with_routing(messages, routing_context, **kwargs)
+            return self._call_llm_with_routing(
+                messages, routing_context, temperature=temperature, model=model, **kwargs
+            )
         if not provider:
             raise LLMServiceError(
                 "provider is required when routing_context is not provided."
@@ -507,7 +509,7 @@ class LLMService:
                     "routing_context['fallback_provider'] to set the fallback."
                 )
             return await self._call_llm_async_with_routing(
-                messages, routing_context, **kwargs
+                messages, routing_context, temperature=temperature, model=model, **kwargs
             )
         if not provider:
             raise LLMServiceError(
@@ -522,7 +524,12 @@ class LLMService:
         )
 
     def _call_llm_with_routing(
-        self, messages: List[Dict[str, str]], routing_context: Dict[str, Any], **kwargs
+        self,
+        messages: List[Dict[str, str]],
+        routing_context: Dict[str, Any],
+        temperature: Optional[float] = None,
+        model: Optional[str] = None,
+        **kwargs,
     ) -> str:
         """
         Make an LLM call using intelligent routing to select provider/model.
@@ -530,6 +537,8 @@ class LLMService:
         Args:
             messages: List of message dictionaries
             routing_context: Dictionary containing routing parameters
+            temperature: Optional temperature override from caller
+            model: Optional model hint (used as fallback if routing fails)
             **kwargs: Additional LLM parameters
 
         Returns:
@@ -606,7 +615,7 @@ class LLMService:
                 provider=decision.provider,
                 messages=messages,
                 model=decision.model,
-                temperature=kwargs.get("temperature"),
+                temperature=temperature,
                 **kwargs,
             )
 
@@ -626,8 +635,8 @@ class LLMService:
             return self._call_llm_direct(
                 provider=fallback_provider,
                 messages=messages,
-                model=kwargs.get("model"),
-                temperature=kwargs.get("temperature"),
+                model=model,
+                temperature=temperature,
                 **kwargs,
             )
 
@@ -722,7 +731,12 @@ class LLMService:
             raise typed_error
 
     async def _call_llm_async_with_routing(
-        self, messages: List[Dict[str, str]], routing_context: Dict[str, Any], **kwargs
+        self,
+        messages: List[Dict[str, str]],
+        routing_context: Dict[str, Any],
+        temperature: Optional[float] = None,
+        model: Optional[str] = None,
+        **kwargs,
     ) -> LLMResponse:
         """Async sibling of ``_call_llm_with_routing`` preserving routing rules.
 
@@ -786,7 +800,7 @@ class LLMService:
                 provider=decision.provider,
                 messages=messages,
                 model=decision.model,
-                temperature=kwargs.get("temperature"),
+                temperature=temperature,
                 **kwargs,
             )
 
@@ -810,8 +824,8 @@ class LLMService:
             return await self._call_llm_async_direct(
                 provider=fallback_provider,
                 messages=messages,
-                model=kwargs.get("model"),
-                temperature=kwargs.get("temperature"),
+                model=model,
+                temperature=temperature,
                 **kwargs,
             )
 

--- a/src/agentmap/services/protocols/service_protocols.py
+++ b/src/agentmap/services/protocols/service_protocols.py
@@ -16,7 +16,7 @@ from typing import (
     runtime_checkable,
 )
 
-from agentmap.models.llm_execution import LLMCallResult, LLMCallSpec
+from agentmap.models.llm_execution import LLMCallResult, LLMCallSpec, LLMResponse
 
 # Declaration system imports
 
@@ -90,9 +90,14 @@ class LLMServiceProtocol(Protocol):
         temperature: Optional[float] = None,
         routing_context: Optional[Dict[str, Any]] = None,
         **kwargs,
-    ) -> str:
+    ) -> LLMResponse:
         """
-        Call LLM asynchronously with specified provider and messages.
+        Call LLM asynchronously and return a rich ``LLMResponse``.
+
+        ``LLMResponse.text`` carries the response text; ``.resolved_provider``
+        and ``.resolved_model`` reflect the provider and model that actually
+        handled the request (after routing or fallback); ``.usage`` carries
+        normalized token counts when the provider returned usage metadata.
 
         Args:
             messages: List of message dictionaries with role and content
@@ -103,7 +108,7 @@ class LLMServiceProtocol(Protocol):
             **kwargs: Additional provider-specific parameters
 
         Returns:
-            LLM response as string
+            LLMResponse with text, resolved provider/model, and usage
         """
         ...
 

--- a/src/agentmap/services/protocols/service_protocols.py
+++ b/src/agentmap/services/protocols/service_protocols.py
@@ -16,6 +16,8 @@ from typing import (
     runtime_checkable,
 )
 
+from agentmap.models.llm_execution import LLMCallResult, LLMCallSpec
+
 # Declaration system imports
 
 if TYPE_CHECKING:
@@ -77,6 +79,79 @@ class LLMServiceProtocol(Protocol):
 
         Returns:
             LLM response as string
+        """
+        ...
+
+    async def call_llm_async(
+        self,
+        messages: List[Dict[str, str]],
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        routing_context: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Call LLM asynchronously with specified provider and messages.
+
+        Args:
+            messages: List of message dictionaries with role and content
+            provider: Optional LLM provider ("openai", "anthropic", "google", etc.)
+            model: Optional model override
+            temperature: Optional temperature override
+            routing_context: Optional routing context for intelligent routing
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            LLM response as string
+        """
+        ...
+
+    async def ask_async(
+        self,
+        prompt: str,
+        provider: Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Ask the LLM a question asynchronously using the text-only interface.
+
+        Args:
+            prompt: The prompt text to send
+            provider: Optional provider name
+            **kwargs: Additional provider-specific parameters
+
+        Returns:
+            LLM response as string
+        """
+        ...
+
+    async def call_llm_many_async(
+        self,
+        call_specs: List[LLMCallSpec],
+        max_concurrency: int,
+    ) -> List[LLMCallResult]:
+        """
+        Submit many LLM call specs and receive one terminal result per spec.
+
+        Submission is validated before any provider execution begins:
+        - ``call_specs`` must not be empty.
+        - ``spec_id`` values must be unique within one submission.
+        - ``max_concurrency`` must be an integer >= 1.
+
+        Once execution starts, per-item failures are captured as ``LLMCallResult``
+        records with ``status="failed"`` rather than aborting the whole submission.
+        The returned list preserves the same positional order as ``call_specs``.
+
+        Args:
+            call_specs: Non-empty list of ``LLMCallSpec`` items.
+            max_concurrency: Maximum number of in-flight provider calls at once.
+
+        Returns:
+            List of ``LLMCallResult`` in the same order as ``call_specs``.
+
+        Raises:
+            LLMServiceError: For invalid submissions (before any execution).
         """
         ...
 

--- a/tests/fresh_suite/unit/services/test_llm_service.py
+++ b/tests/fresh_suite/unit/services/test_llm_service.py
@@ -172,23 +172,24 @@ class TestLLMService(unittest.TestCase):
 
             mock_direct_call.return_value = "Routed response"
 
-            # Execute test
+            # Execute test — pass temperature to verify it survives routing (B002)
             messages = [{"role": "user", "content": "Complex task"}]
             result = self.service.call_llm(
                 provider="openai",  # This should be overridden by routing
                 messages=messages,
+                temperature=0.3,
                 routing_context=routing_context,
             )
 
             # Verify routing was used
             self.mock_routing_service.route_request.assert_called_once()
 
-            # Verify direct call was made with routed provider
+            # Verify direct call was made with routed provider and caller's temperature
             mock_direct_call.assert_called_once_with(
                 provider="anthropic",
                 messages=messages,
                 model="claude-3-7-sonnet-20250219",
-                temperature=None,
+                temperature=0.3,
             )
 
             self.assertEqual(result, "Routed response")
@@ -206,18 +207,22 @@ class TestLLMService(unittest.TestCase):
         with patch.object(self.service, "_call_llm_direct") as mock_direct_call:
             mock_direct_call.return_value = "Fallback response"
 
-            # Execute test
+            # Execute test — pass temperature and model to verify they survive fallback (B002)
             messages = [{"role": "user", "content": "Test"}]
             result = self.service.call_llm(
-                provider="anthropic", messages=messages, routing_context=routing_context
+                provider="anthropic",
+                messages=messages,
+                model="custom-model",
+                temperature=0.5,
+                routing_context=routing_context,
             )
 
-            # Verify fallback to direct call
+            # Verify fallback preserves caller's model and temperature
             mock_direct_call.assert_called_with(
                 provider="openai",  # fallback_provider
                 messages=messages,
-                model=None,
-                temperature=None,
+                model="custom-model",
+                temperature=0.5,
             )
 
             self.assertEqual(result, "Fallback response")

--- a/tests/fresh_suite/unit/services/test_llm_service_async.py
+++ b/tests/fresh_suite/unit/services/test_llm_service_async.py
@@ -6,6 +6,7 @@ import unittest
 from unittest.mock import AsyncMock, Mock, create_autospec, patch
 
 from agentmap.exceptions import LLMConfigurationError, LLMTimeoutError
+from agentmap.exceptions.service_exceptions import LLMResolvedCallError
 from agentmap.models.llm_execution import LLMResponse
 from agentmap.services.llm_service import LLMService
 from agentmap.services.protocols import LLMServiceProtocol
@@ -46,6 +47,7 @@ class TestMockLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
 
         # call_llm_async returns LLMResponse; .text carries the response string.
         from agentmap.models.llm_execution import LLMResponse
+
         self.assertIsInstance(response, LLMResponse)
         self.assertEqual(response.text, "Mock LLM response")
         self.assertTrue(hasattr(mock_service, "ask"))
@@ -329,14 +331,16 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
                 new=AsyncMock(),
             ) as mock_sleep,
         ):
-            with self.assertRaisesRegex(
-                LLMConfigurationError, "Invalid api_key|api_key"
-            ):
+            # Non-retryable errors are wrapped in LLMResolvedCallError so
+            # callers get both the resolved identity and the underlying cause.
+            with self.assertRaises(LLMResolvedCallError) as ctx:
                 await self.service.call_llm_async(
                     messages=[{"role": "user", "content": "hello"}],
                     provider="openai",
                     model="gpt-4o-mini",
                 )
+            self.assertIsInstance(ctx.exception.cause, LLMConfigurationError)
+            self.assertRegex(str(ctx.exception.cause), "Invalid api_key|api_key")
 
         self.assertEqual(mock_client.ainvoke.await_count, 1)
         mock_sleep.assert_not_awaited()
@@ -415,12 +419,18 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
                 new=AsyncMock(),
             ) as mock_sleep,
         ):
-            with self.assertRaises(LLMTimeoutError):
+            # call_llm_async propagates LLMResolvedCallError (which is a
+            # LLMServiceError subclass) carrying the resolved identity and the
+            # underlying LLMTimeoutError as .cause.
+            with self.assertRaises(LLMResolvedCallError) as ctx:
                 await self.service.call_llm_async(
                     messages=[{"role": "user", "content": "hello"}],
                     provider="openai",
                     model="gpt-4o-mini",
                 )
+            self.assertIsInstance(ctx.exception.cause, LLMTimeoutError)
+            self.assertEqual(ctx.exception.resolved_provider, "openai")
+            self.assertEqual(ctx.exception.resolved_model, "gpt-4o-mini")
 
         self.assertEqual(mock_client.ainvoke.await_count, 3)
         self.assertEqual(mock_sleep.await_count, 2)

--- a/tests/fresh_suite/unit/services/test_llm_service_async.py
+++ b/tests/fresh_suite/unit/services/test_llm_service_async.py
@@ -1,0 +1,400 @@
+"""
+Async contract tests for LLM service protocols and test doubles.
+"""
+
+import unittest
+from unittest.mock import AsyncMock, Mock, create_autospec, patch
+
+from agentmap.exceptions import LLMConfigurationError, LLMTimeoutError
+from agentmap.services.llm_service import LLMService
+from agentmap.services.protocols import LLMServiceProtocol
+from tests.utils.mock_service_factory import MockServiceFactory
+
+
+class TestLLMServiceAsyncProtocol(unittest.TestCase):
+    """Contract tests for additive async LLM service protocol changes."""
+
+    def test_protocol_autospec_preserves_sync_members(self):
+        """Sync members remain available after adding async siblings."""
+        mock_service = create_autospec(LLMServiceProtocol, instance=True)
+
+        self.assertTrue(hasattr(mock_service, "call_llm"))
+        self.assertTrue(hasattr(mock_service, "ask_vision"))
+
+    def test_protocol_autospec_exposes_async_siblings(self):
+        """Async protocol methods are available as awaitable mocks."""
+        mock_service = create_autospec(LLMServiceProtocol, instance=True)
+
+        self.assertTrue(hasattr(mock_service, "call_llm_async"))
+        self.assertTrue(hasattr(mock_service, "ask_async"))
+        self.assertIsInstance(mock_service.call_llm_async, AsyncMock)
+        self.assertIsInstance(mock_service.ask_async, AsyncMock)
+
+
+class TestMockLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
+    """Tests for async-capable LLM service test doubles."""
+
+    async def test_mock_service_exposes_async_siblings(self):
+        """MockServiceFactory creates a test double with awaitable async methods."""
+        mock_service = MockServiceFactory.create_mock_llm_service()
+
+        response = await mock_service.call_llm_async(
+            messages=[{"role": "user", "content": "hello"}],
+            provider="anthropic",
+        )
+
+        self.assertEqual(response, "Mock LLM response")
+        self.assertTrue(hasattr(mock_service, "ask"))
+        self.assertTrue(hasattr(mock_service, "call_llm_async"))
+        self.assertTrue(hasattr(mock_service, "ask_async"))
+
+    async def test_mock_service_async_ask_matches_sync_default_response(self):
+        """Async ask helper returns the same basic test-double response."""
+        mock_service = MockServiceFactory.create_mock_llm_service()
+
+        response = await mock_service.ask_async("hello")
+
+        self.assertEqual(response, "Mock LLM response")
+
+
+class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
+    """Behavior tests for the async LLM service surface."""
+
+    def setUp(self):
+        self.mock_logging_service = MockServiceFactory.create_mock_logging_service()
+        self.mock_app_config_service = (
+            MockServiceFactory.create_mock_app_config_service()
+        )
+        self.mock_app_config_service.get_llm_resilience_config.return_value = {
+            "retry": {
+                "max_attempts": 3,
+                "backoff_base": 2.0,
+                "backoff_max": 30.0,
+                "jitter": False,
+            },
+            "circuit_breaker": {
+                "failure_threshold": 3,
+                "reset_timeout": 60,
+            },
+        }
+        self.mock_app_config_service.get_llm_config.side_effect = lambda provider: {
+            "model": f"{provider}-default-model",
+            "api_key": "test-key",
+            "temperature": 0.7,
+        }
+        self.mock_llm_models_config_service = (
+            MockServiceFactory.create_mock_llm_models_config_service()
+        )
+        self.mock_routing_service = Mock()
+
+        self.service = LLMService(
+            configuration=self.mock_app_config_service,
+            logging_service=self.mock_logging_service,
+            routing_service=self.mock_routing_service,
+            llm_models_config_service=self.mock_llm_models_config_service,
+        )
+
+    async def test_call_llm_async_uses_native_async_provider_surface(self):
+        """Native async clients should be awaited instead of using sync invoke."""
+        mock_client = Mock()
+        mock_client.ainvoke = AsyncMock(return_value=Mock(content="async response"))
+        mock_client.invoke = Mock()
+        langchain_messages = [Mock()]
+
+        with (
+            patch.object(
+                self.service._client_factory,
+                "get_or_create_client",
+                return_value=mock_client,
+            ),
+            patch.object(
+                self.service._message_utils,
+                "convert_messages_to_langchain",
+                return_value=langchain_messages,
+            ),
+        ):
+            result = await self.service.call_llm_async(
+                messages=[{"role": "user", "content": "hello"}],
+                provider="openai",
+                model="gpt-4o-mini",
+                temperature=0.2,
+                max_tokens=77,
+            )
+
+        self.assertEqual(result, "async response")
+        mock_client.ainvoke.assert_awaited_once_with(langchain_messages)
+        mock_client.invoke.assert_not_called()
+
+    async def test_call_llm_async_offloads_sync_only_client_to_worker_thread(self):
+        """Sync-only clients should be invoked through the thread-offload seam."""
+        mock_client = Mock()
+        mock_client.invoke.return_value = Mock(content="compat response")
+        langchain_messages = [Mock()]
+
+        async def fake_to_thread(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with (
+            patch.object(
+                self.service._client_factory,
+                "get_or_create_client",
+                return_value=mock_client,
+            ),
+            patch.object(
+                self.service._message_utils,
+                "convert_messages_to_langchain",
+                return_value=langchain_messages,
+            ),
+            patch(
+                "agentmap.services.llm_service.asyncio.to_thread",
+                new=AsyncMock(side_effect=fake_to_thread),
+            ) as mock_to_thread,
+        ):
+            result = await self.service.call_llm_async(
+                messages=[{"role": "user", "content": "hello"}],
+                provider="anthropic",
+            )
+
+        self.assertEqual(result, "compat response")
+        mock_to_thread.assert_awaited_once()
+        mock_client.invoke.assert_called_once_with(langchain_messages)
+
+    async def test_call_llm_async_routing_ignores_explicit_provider_and_model(self):
+        """Routing should own provider/model selection and log sync-parity warnings."""
+        mock_decision = Mock()
+        mock_decision.provider = "anthropic"
+        mock_decision.model = "claude-3-7-sonnet-20250219"
+        mock_decision.complexity = "medium"
+        mock_decision.confidence = 0.91
+        mock_decision.max_tokens = 64
+        mock_decision.cache_hit = False
+        mock_decision.fallback_used = False
+        self.mock_routing_service.route_request.return_value = mock_decision
+
+        with patch.object(
+            self.service,
+            "_call_llm_async_direct",
+            new=AsyncMock(return_value="routed response"),
+        ) as mock_direct:
+            result = await self.service.call_llm_async(
+                messages=[{"role": "user", "content": "complex task"}],
+                provider="openai",
+                model="ignored",
+                routing_context={
+                    "routing_enabled": True,
+                    "provider_preference": ["anthropic"],
+                    "fallback_provider": "google",
+                    "max_tokens": 64,
+                },
+            )
+
+        self.assertEqual(result, "routed response")
+        mock_direct.assert_awaited_once_with(
+            provider="anthropic",
+            messages=[{"role": "user", "content": "complex task"}],
+            model="claude-3-7-sonnet-20250219",
+            temperature=None,
+            max_tokens=64,
+        )
+        self.assertEqual(self.service._logger.warning.call_count, 2)
+
+    async def test_call_llm_async_routing_failure_uses_fallback_provider(self):
+        """Routing failure should preserve fallback-provider async behavior."""
+        self.mock_routing_service.route_request.side_effect = Exception(
+            "routing failed"
+        )
+
+        with patch.object(
+            self.service,
+            "_call_llm_async_direct",
+            new=AsyncMock(return_value="fallback response"),
+        ) as mock_direct:
+            result = await self.service.call_llm_async(
+                messages=[{"role": "user", "content": "test"}],
+                provider="anthropic",
+                routing_context={
+                    "routing_enabled": True,
+                    "fallback_provider": "openai",
+                    "max_tokens": 128,
+                },
+            )
+
+        self.assertEqual(result, "fallback response")
+        mock_direct.assert_awaited_once_with(
+            provider="openai",
+            messages=[{"role": "user", "content": "test"}],
+            model=None,
+            temperature=None,
+            max_tokens=128,
+        )
+
+    async def test_ask_async_defaults_provider_and_shapes_messages_like_ask(self):
+        """ask_async should mirror ask() default provider and message shaping."""
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(return_value="default response"),
+        ) as mock_call_llm_async:
+            result = await self.service.ask_async("Hello", temperature=0.8)
+
+        self.assertEqual(result, "default response")
+        mock_call_llm_async.assert_awaited_once_with(
+            provider="anthropic",
+            messages=[{"role": "user", "content": "Hello"}],
+            temperature=0.8,
+        )
+
+    async def test_call_llm_async_retries_with_async_sleep_and_records_success(self):
+        """Retryable async failures should back off via asyncio.sleep and recover."""
+        mock_client = Mock()
+        mock_client.ainvoke = AsyncMock(
+            side_effect=[
+                RuntimeError("Connection timeout"),
+                Mock(content="recovered"),
+            ]
+        )
+        langchain_messages = [Mock()]
+
+        with (
+            patch.object(
+                self.service._client_factory,
+                "get_or_create_client",
+                return_value=mock_client,
+            ),
+            patch.object(
+                self.service._message_utils,
+                "convert_messages_to_langchain",
+                return_value=langchain_messages,
+            ),
+            patch(
+                "agentmap.services.llm_service.asyncio.sleep",
+                new=AsyncMock(),
+            ) as mock_sleep,
+        ):
+            result = await self.service.call_llm_async(
+                messages=[{"role": "user", "content": "hello"}],
+                provider="openai",
+                model="gpt-4o-mini",
+            )
+
+        self.assertEqual(result, "recovered")
+        self.assertEqual(mock_client.ainvoke.await_count, 2)
+        mock_sleep.assert_awaited_once()
+        self.assertEqual(self.service._circuit_breaker.failures, {})
+
+    async def test_call_llm_async_non_retryable_failure_is_terminal(self):
+        """Non-retryable async failures should preserve sync error classification."""
+        mock_client = Mock()
+        mock_client.ainvoke = AsyncMock(side_effect=RuntimeError("Invalid api_key"))
+
+        with (
+            patch.object(
+                self.service._client_factory,
+                "get_or_create_client",
+                return_value=mock_client,
+            ),
+            patch.object(
+                self.service._message_utils,
+                "convert_messages_to_langchain",
+                return_value=[Mock()],
+            ),
+            patch(
+                "agentmap.services.llm_service.asyncio.sleep",
+                new=AsyncMock(),
+            ) as mock_sleep,
+        ):
+            with self.assertRaisesRegex(
+                LLMConfigurationError, "Invalid api_key|api_key"
+            ):
+                await self.service.call_llm_async(
+                    messages=[{"role": "user", "content": "hello"}],
+                    provider="openai",
+                    model="gpt-4o-mini",
+                )
+
+        self.assertEqual(mock_client.ainvoke.await_count, 1)
+        mock_sleep.assert_not_awaited()
+
+    async def test_call_llm_async_uses_configured_fallback_handler(self):
+        """Async direct-call failures should reuse configured tiered fallback logic."""
+        mock_features_registry = Mock()
+        mock_features_registry.is_provider_available.return_value = True
+        mock_routing_config = Mock()
+        mock_routing_config.fallback = {"default_provider": "anthropic"}
+        mock_routing_config.routing_matrix = {"anthropic": {"low": "claude-haiku"}}
+
+        service = LLMService(
+            configuration=self.mock_app_config_service,
+            logging_service=self.mock_logging_service,
+            routing_service=self.mock_routing_service,
+            llm_models_config_service=self.mock_llm_models_config_service,
+            features_registry_service=mock_features_registry,
+            routing_config_service=mock_routing_config,
+        )
+        service._provider_utils.normalize_provider = Mock(side_effect=lambda p: p)
+        service._provider_utils.get_provider_config = Mock(
+            side_effect=lambda provider: {
+                "model": f"{provider}-default-model",
+                "api_key": "test-key",
+            }
+        )
+        service._message_utils.convert_messages_to_langchain = Mock(
+            return_value=[Mock()]
+        )
+
+        failing_client = Mock()
+        failing_client.ainvoke = AsyncMock(
+            side_effect=RuntimeError("Connection timeout")
+        )
+        fallback_client = Mock()
+        fallback_client.invoke.return_value = Mock(content="fallback response")
+
+        def fake_get_client(provider, config):
+            return failing_client if provider == "openai" else fallback_client
+
+        service._client_factory.get_or_create_client = Mock(side_effect=fake_get_client)
+
+        result = await service.call_llm_async(
+            messages=[{"role": "user", "content": "hello"}],
+            provider="openai",
+            model="gpt-4o-mini",
+        )
+
+        self.assertEqual(result, "fallback response")
+
+    async def test_call_llm_async_exhausted_retries_open_circuit(self):
+        """Retry exhaustion should classify the error and open the circuit like sync."""
+        self.service._resilience_config["retry"]["max_attempts"] = 3
+        self.service._resilience_config["retry"]["jitter"] = False
+        self.service._resilience_config["circuit_breaker"]["failure_threshold"] = 1
+        self.service._circuit_breaker.threshold = 1
+
+        mock_client = Mock()
+        mock_client.ainvoke = AsyncMock(side_effect=RuntimeError("Connection timeout"))
+
+        with (
+            patch.object(
+                self.service._client_factory,
+                "get_or_create_client",
+                return_value=mock_client,
+            ),
+            patch.object(
+                self.service._message_utils,
+                "convert_messages_to_langchain",
+                return_value=[Mock()],
+            ),
+            patch(
+                "agentmap.services.llm_service.asyncio.sleep",
+                new=AsyncMock(),
+            ) as mock_sleep,
+        ):
+            with self.assertRaises(LLMTimeoutError):
+                await self.service.call_llm_async(
+                    messages=[{"role": "user", "content": "hello"}],
+                    provider="openai",
+                    model="gpt-4o-mini",
+                )
+
+        self.assertEqual(mock_client.ainvoke.await_count, 3)
+        self.assertEqual(mock_sleep.await_count, 2)
+        self.assertIn("openai:gpt-4o-mini", self.service._circuit_breaker.opened_at)

--- a/tests/fresh_suite/unit/services/test_llm_service_async.py
+++ b/tests/fresh_suite/unit/services/test_llm_service_async.py
@@ -378,7 +378,9 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
             side_effect=RuntimeError("Connection timeout")
         )
         fallback_client = Mock()
-        fallback_client.ainvoke = None  # Sync-only fallback — forces the to_thread path.
+        fallback_client.ainvoke = (
+            None  # Sync-only fallback — forces the to_thread path.
+        )
         fallback_client.invoke.return_value = Mock(content="fallback response")
 
         def fake_get_client(provider, config):

--- a/tests/fresh_suite/unit/services/test_llm_service_async.py
+++ b/tests/fresh_suite/unit/services/test_llm_service_async.py
@@ -6,6 +6,7 @@ import unittest
 from unittest.mock import AsyncMock, Mock, create_autospec, patch
 
 from agentmap.exceptions import LLMConfigurationError, LLMTimeoutError
+from agentmap.models.llm_execution import LLMResponse
 from agentmap.services.llm_service import LLMService
 from agentmap.services.protocols import LLMServiceProtocol
 from tests.utils.mock_service_factory import MockServiceFactory
@@ -43,7 +44,10 @@ class TestMockLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
             provider="anthropic",
         )
 
-        self.assertEqual(response, "Mock LLM response")
+        # call_llm_async returns LLMResponse; .text carries the response string.
+        from agentmap.models.llm_execution import LLMResponse
+        self.assertIsInstance(response, LLMResponse)
+        self.assertEqual(response.text, "Mock LLM response")
         self.assertTrue(hasattr(mock_service, "ask"))
         self.assertTrue(hasattr(mock_service, "call_llm_async"))
         self.assertTrue(hasattr(mock_service, "ask_async"))
@@ -121,7 +125,9 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
                 max_tokens=77,
             )
 
-        self.assertEqual(result, "async response")
+        self.assertIsInstance(result, LLMResponse)
+        self.assertEqual(result.text, "async response")
+        self.assertEqual(result.resolved_provider, "openai")
         mock_client.ainvoke.assert_awaited_once_with(langchain_messages)
         mock_client.invoke.assert_not_called()
 
@@ -155,7 +161,8 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
                 provider="anthropic",
             )
 
-        self.assertEqual(result, "compat response")
+        self.assertIsInstance(result, LLMResponse)
+        self.assertEqual(result.text, "compat response")
         mock_to_thread.assert_awaited_once()
         mock_client.invoke.assert_called_once_with(langchain_messages)
 
@@ -171,10 +178,15 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
         mock_decision.fallback_used = False
         self.mock_routing_service.route_request.return_value = mock_decision
 
+        routed_response = LLMResponse(
+            text="routed response",
+            resolved_provider="anthropic",
+            resolved_model="claude-3-7-sonnet-20250219",
+        )
         with patch.object(
             self.service,
             "_call_llm_async_direct",
-            new=AsyncMock(return_value="routed response"),
+            new=AsyncMock(return_value=routed_response),
         ) as mock_direct:
             result = await self.service.call_llm_async(
                 messages=[{"role": "user", "content": "complex task"}],
@@ -188,7 +200,8 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
                 },
             )
 
-        self.assertEqual(result, "routed response")
+        self.assertIsInstance(result, LLMResponse)
+        self.assertEqual(result.text, "routed response")
         mock_direct.assert_awaited_once_with(
             provider="anthropic",
             messages=[{"role": "user", "content": "complex task"}],
@@ -204,10 +217,15 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
             "routing failed"
         )
 
+        fallback_response = LLMResponse(
+            text="fallback response",
+            resolved_provider="openai",
+            resolved_model="openai-default-model",
+        )
         with patch.object(
             self.service,
             "_call_llm_async_direct",
-            new=AsyncMock(return_value="fallback response"),
+            new=AsyncMock(return_value=fallback_response),
         ) as mock_direct:
             result = await self.service.call_llm_async(
                 messages=[{"role": "user", "content": "test"}],
@@ -219,7 +237,8 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
                 },
             )
 
-        self.assertEqual(result, "fallback response")
+        self.assertIsInstance(result, LLMResponse)
+        self.assertEqual(result.text, "fallback response")
         mock_direct.assert_awaited_once_with(
             provider="openai",
             messages=[{"role": "user", "content": "test"}],
@@ -233,7 +252,13 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
         with patch.object(
             self.service,
             "call_llm_async",
-            new=AsyncMock(return_value="default response"),
+            new=AsyncMock(
+                return_value=LLMResponse(
+                    text="default response",
+                    resolved_provider="anthropic",
+                    resolved_model="anthropic-default-model",
+                )
+            ),
         ) as mock_call_llm_async:
             result = await self.service.ask_async("Hello", temperature=0.8)
 
@@ -277,7 +302,8 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
                 model="gpt-4o-mini",
             )
 
-        self.assertEqual(result, "recovered")
+        self.assertIsInstance(result, LLMResponse)
+        self.assertEqual(result.text, "recovered")
         self.assertEqual(mock_client.ainvoke.await_count, 2)
         mock_sleep.assert_awaited_once()
         self.assertEqual(self.service._circuit_breaker.failures, {})
@@ -360,7 +386,8 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
             model="gpt-4o-mini",
         )
 
-        self.assertEqual(result, "fallback response")
+        self.assertIsInstance(result, LLMResponse)
+        self.assertEqual(result.text, "fallback response")
 
     async def test_call_llm_async_exhausted_retries_open_circuit(self):
         """Retry exhaustion should classify the error and open the circuit like sync."""

--- a/tests/fresh_suite/unit/services/test_llm_service_async.py
+++ b/tests/fresh_suite/unit/services/test_llm_service_async.py
@@ -136,6 +136,7 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
     async def test_call_llm_async_offloads_sync_only_client_to_worker_thread(self):
         """Sync-only clients should be invoked through the thread-offload seam."""
         mock_client = Mock()
+        mock_client.ainvoke = None  # No async surface — forces the to_thread path.
         mock_client.invoke.return_value = Mock(content="compat response")
         langchain_messages = [Mock()]
 
@@ -377,6 +378,7 @@ class TestLLMServiceAsync(unittest.IsolatedAsyncioTestCase):
             side_effect=RuntimeError("Connection timeout")
         )
         fallback_client = Mock()
+        fallback_client.ainvoke = None  # Sync-only fallback — forces the to_thread path.
         fallback_client.invoke.return_value = Mock(content="fallback response")
 
         def fake_get_client(provider, config):

--- a/tests/fresh_suite/unit/services/test_llm_service_fanout.py
+++ b/tests/fresh_suite/unit/services/test_llm_service_fanout.py
@@ -122,8 +122,8 @@ class TestAC002OneResultPerSpec(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "call_llm_async",
-            new=AsyncMock(return_value="response"),
+            "_call_llm_async_with_response",
+            new=AsyncMock(return_value=("response", None)),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=2)
 
@@ -138,8 +138,8 @@ class TestAC002OneResultPerSpec(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "call_llm_async",
-            new=AsyncMock(return_value="hello"),
+            "_call_llm_async_with_response",
+            new=AsyncMock(return_value=("hello", None)),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=1)
 
@@ -155,8 +155,8 @@ class TestAC002OneResultPerSpec(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "call_llm_async",
-            new=AsyncMock(return_value="ok"),
+            "_call_llm_async_with_response",
+            new=AsyncMock(return_value=("ok", None)),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=8)
 
@@ -190,13 +190,13 @@ class TestAC003StableOrdering(unittest.IsolatedAsyncioTestCase):
             # Simulate: spec_b finishes quickly, spec_c next, spec_a last
             delays = [0.02, 0.00, 0.01]
             await asyncio.sleep(delays[idx])
-            return f"response-{idx}"
+            return f"response-{idx}", None
 
         specs = [_make_spec("spec-a"), _make_spec("spec-b"), _make_spec("spec-c")]
 
         with patch.object(
             self.service,
-            "call_llm_async",
+            "_call_llm_async_with_response",
             new=AsyncMock(side_effect=ordered_response),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=3)
@@ -212,8 +212,8 @@ class TestAC003StableOrdering(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "call_llm_async",
-            new=AsyncMock(return_value="content"),
+            "_call_llm_async_with_response",
+            new=AsyncMock(return_value=("content", None)),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=2)
 
@@ -234,7 +234,9 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
 
     async def test_tc_ac4_01_empty_call_specs_raises_before_execution(self):
         """TC-AC4-01: empty call_specs must raise LLMServiceError."""
-        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
+        with patch.object(
+            self.service, "_call_llm_async_with_response", new=AsyncMock()
+        ) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async([], max_concurrency=1)
 
@@ -244,7 +246,9 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         """TC-AC4-02: duplicate spec_id raises LLMServiceError before execution."""
         specs = [_make_spec("dup-1"), _make_spec("dup-1")]
 
-        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
+        with patch.object(
+            self.service, "_call_llm_async_with_response", new=AsyncMock()
+        ) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=2)
 
@@ -255,7 +259,9 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         specs = [_make_spec(f"item-{i}") for i in range(20)]
         specs.append(_make_spec("item-5"))  # duplicate at the end
 
-        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
+        with patch.object(
+            self.service, "_call_llm_async_with_response", new=AsyncMock()
+        ) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=4)
 
@@ -265,7 +271,9 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         """TC-AC4-03: max_concurrency=0 raises LLMServiceError."""
         specs = [_make_spec("one")]
 
-        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
+        with patch.object(
+            self.service, "_call_llm_async_with_response", new=AsyncMock()
+        ) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=0)
 
@@ -275,7 +283,9 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         """TC-AC4-03 edge: max_concurrency=-1 raises LLMServiceError."""
         specs = [_make_spec("one")]
 
-        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
+        with patch.object(
+            self.service, "_call_llm_async_with_response", new=AsyncMock()
+        ) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=-1)
 
@@ -287,8 +297,8 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "call_llm_async",
-            new=AsyncMock(return_value="ok"),
+            "_call_llm_async_with_response",
+            new=AsyncMock(return_value=("ok", None)),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=1)
 
@@ -318,12 +328,14 @@ class TestAC005ConcurrencyCap(unittest.IsolatedAsyncioTestCase):
             max_observed[0] = max(max_observed[0], in_flight[0])
             await asyncio.sleep(0.01)
             in_flight[0] -= 1
-            return "ok"
+            return "ok", None
 
         specs = [_make_spec(f"s{i}") for i in range(5)]
 
         with patch.object(
-            self.service, "call_llm_async", new=AsyncMock(side_effect=probe)
+            self.service,
+            "_call_llm_async_with_response",
+            new=AsyncMock(side_effect=probe),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=cap)
 
@@ -337,12 +349,14 @@ class TestAC005ConcurrencyCap(unittest.IsolatedAsyncioTestCase):
         async def record_call(*args, **kwargs):
             spec_id = kwargs.get("messages", [{}])[0].get("content", "?")
             call_order.append(spec_id)
-            return "ok"
+            return "ok", None
 
         specs = [_make_spec(f"seq-{i}") for i in range(3)]
 
         with patch.object(
-            self.service, "call_llm_async", new=AsyncMock(side_effect=record_call)
+            self.service,
+            "_call_llm_async_with_response",
+            new=AsyncMock(side_effect=record_call),
         ):
             await self.service.call_llm_many_async(specs, max_concurrency=1)
 
@@ -355,15 +369,20 @@ class TestAC005ConcurrencyCap(unittest.IsolatedAsyncioTestCase):
 
         async def echo(*args, **kwargs):
             messages = kwargs.get("messages", [])
-            return messages[0]["content"] if messages else "?"
+            text = messages[0]["content"] if messages else "?"
+            return text, None
 
         with patch.object(
-            self.service, "call_llm_async", new=AsyncMock(side_effect=echo)
+            self.service,
+            "_call_llm_async_with_response",
+            new=AsyncMock(side_effect=echo),
         ):
             results_1 = await self.service.call_llm_many_async(specs, max_concurrency=1)
 
         with patch.object(
-            self.service, "call_llm_async", new=AsyncMock(side_effect=echo)
+            self.service,
+            "_call_llm_async_with_response",
+            new=AsyncMock(side_effect=echo),
         ):
             results_3 = await self.service.call_llm_many_async(specs, max_concurrency=3)
 
@@ -392,10 +411,12 @@ class TestAC006PartialFailure(unittest.IsolatedAsyncioTestCase):
             content = messages[0]["content"] if messages else ""
             if "fail-b" in content:
                 raise RuntimeError("provider error")
-            return "success"
+            return "success", None
 
         with patch.object(
-            self.service, "call_llm_async", new=AsyncMock(side_effect=mixed_response)
+            self.service,
+            "_call_llm_async_with_response",
+            new=AsyncMock(side_effect=mixed_response),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=3)
 
@@ -411,7 +432,7 @@ class TestAC006PartialFailure(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "call_llm_async",
+            "_call_llm_async_with_response",
             new=AsyncMock(side_effect=RuntimeError("boom")),
         ):
             # Must not raise — returns a failure result instead
@@ -430,10 +451,12 @@ class TestAC006PartialFailure(unittest.IsolatedAsyncioTestCase):
             if "fast-fail" in content:
                 raise RuntimeError("fast error")
             await asyncio.sleep(0.02)
-            return "slow result"
+            return "slow result", None
 
         with patch.object(
-            self.service, "call_llm_async", new=AsyncMock(side_effect=behavior)
+            self.service,
+            "_call_llm_async_with_response",
+            new=AsyncMock(side_effect=behavior),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=2)
 
@@ -459,10 +482,12 @@ class TestAC007SuccessNormalization(unittest.IsolatedAsyncioTestCase):
         """TC-AC7-01: successful result carries spec_id, status=succeeded, content."""
         spec = _make_spec("result-check", provider="openai", model="gpt-4o-mini")
 
+        # _execute_fan_out_item calls _call_llm_async_with_response (the lower seam)
+        # rather than call_llm_async so that raw response usage is accessible.
         with patch.object(
             self.service,
-            "call_llm_async",
-            new=AsyncMock(return_value="great answer"),
+            "_call_llm_async_with_response",
+            new=AsyncMock(return_value=("great answer", None)),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
 
@@ -477,14 +502,96 @@ class TestAC007SuccessNormalization(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "call_llm_async",
-            new=AsyncMock(return_value="reply"),
+            "_call_llm_async_with_response",
+            new=AsyncMock(return_value=("reply", None)),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
 
         r = results[0]
         self.assertEqual(r.provider, "anthropic")
         self.assertEqual(r.model, "claude-3-haiku")
+
+    async def test_tc_ac7_01_full_usage_metadata_is_normalized_onto_result(self):
+        """TC-AC7-01 end-to-end: result.usage carries all token fields from raw response.
+
+        Counter-factual: with usage=None hardcoded, result.usage would be None and
+        the assertions below would fail.  This test MUST fail before the B-1 fix.
+        """
+        spec = _make_spec("usage-full", provider="anthropic", model="claude-3-haiku")
+
+        # Construct a fake raw response object that carries usage_metadata with all
+        # four token fields — the same shape a real Anthropic response returns.
+        fake_response = Mock()
+        fake_response.content = "answer with usage"
+        fake_response.usage_metadata = {
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "cache_creation_input_tokens": 20,
+            "cache_read_input_tokens": 10,
+        }
+
+        # Drive via the new _call_llm_async_with_response seam that returns
+        # (text, raw_response).  _execute_fan_out_item calls this seam rather
+        # than call_llm_async so that it can extract usage from the raw response.
+        async def fake_with_response(**kwargs):
+            return ("answer with usage", fake_response)
+
+        with patch.object(
+            self.service,
+            "_call_llm_async_with_response",
+            new=AsyncMock(side_effect=fake_with_response),
+        ):
+            results = await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.status, "succeeded")
+        self.assertEqual(r.content, "answer with usage")
+        self.assertIsNotNone(
+            r.usage, "result.usage must not be None when usage_metadata is present"
+        )
+        self.assertIsInstance(r.usage, LLMUsage)
+        self.assertEqual(r.usage.input_tokens, 100)
+        self.assertEqual(r.usage.output_tokens, 50)
+        self.assertEqual(r.usage.cache_creation_input_tokens, 20)
+        self.assertEqual(r.usage.cache_read_input_tokens, 10)
+
+    async def test_tc_ac7_02_partial_usage_metadata_leaves_absent_fields_as_none(self):
+        """TC-AC7-02 end-to-end: absent cache fields remain None; available fields are set.
+
+        Counter-factual: with usage=None hardcoded, result.usage would be None
+        and this test would fail.  It MUST fail before the B-1 fix.
+        """
+        spec = _make_spec("usage-partial", provider="openai", model="gpt-4o")
+
+        fake_response = Mock()
+        fake_response.content = "partial usage answer"
+        # Only the base token counts present; cache fields absent.
+        fake_response.usage_metadata = {
+            "input_tokens": 80,
+            "output_tokens": 30,
+        }
+
+        async def fake_with_response(**kwargs):
+            return ("partial usage answer", fake_response)
+
+        with patch.object(
+            self.service,
+            "_call_llm_async_with_response",
+            new=AsyncMock(side_effect=fake_with_response),
+        ):
+            results = await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.status, "succeeded")
+        self.assertIsNotNone(
+            r.usage, "result.usage must not be None when usage_metadata is present"
+        )
+        self.assertIsInstance(r.usage, LLMUsage)
+        self.assertEqual(r.usage.input_tokens, 80)
+        self.assertEqual(r.usage.output_tokens, 30)
+        # Absent fields must remain None rather than being fabricated.
+        self.assertIsNone(r.usage.cache_creation_input_tokens)
+        self.assertIsNone(r.usage.cache_read_input_tokens)
 
 
 # ---------------------------------------------------------------------------
@@ -504,7 +611,7 @@ class TestAC008FailureNormalization(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "call_llm_async",
+            "_call_llm_async_with_response",
             new=AsyncMock(side_effect=RuntimeError("Connection timeout")),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
@@ -523,7 +630,7 @@ class TestAC008FailureNormalization(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "call_llm_async",
+            "_call_llm_async_with_response",
             new=AsyncMock(side_effect=ValueError("routing failed")),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
@@ -541,7 +648,7 @@ class TestAC008FailureNormalization(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "call_llm_async",
+            "_call_llm_async_with_response",
             new=AsyncMock(side_effect=RuntimeError("routing error")),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
@@ -579,11 +686,11 @@ class TestAC009CacheAwarePassThrough(unittest.IsolatedAsyncioTestCase):
 
         async def capture_call(**kwargs):
             captured_kwargs.update(kwargs)
-            return "cached response"
+            return "cached response", None
 
         with patch.object(
             self.service,
-            "call_llm_async",
+            "_call_llm_async_with_response",
             new=AsyncMock(side_effect=capture_call),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
@@ -609,11 +716,11 @@ class TestAC009CacheAwarePassThrough(unittest.IsolatedAsyncioTestCase):
         async def raise_for_cache(**kwargs):
             if kwargs.get("requires_prompt_caching"):
                 raise LLMServiceError("Provider does not support prompt caching")
-            return "ok"
+            return "ok", None
 
         with patch.object(
             self.service,
-            "call_llm_async",
+            "_call_llm_async_with_response",
             new=AsyncMock(side_effect=raise_for_cache),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=2)

--- a/tests/fresh_suite/unit/services/test_llm_service_fanout.py
+++ b/tests/fresh_suite/unit/services/test_llm_service_fanout.py
@@ -1133,13 +1133,21 @@ class TestAC008FailureNormalizationRound2(unittest.IsolatedAsyncioTestCase):
 
         Counter-factual: against the pre-round-2 code (no LLMResolvedCallError), the
         bare ``except Exception`` in ``_execute_fan_out_item`` populates
-        ``provider=spec.provider=None`` and the assertion ``r.provider == "anthropic"``
+        ``provider=spec.provider=None`` and the assertion ``r.provider == "google"``
         FAILS.
+
+        Discrimination fix (round-3 UAT): routed_provider="google" is deliberately
+        DIFFERENT from the routing fallback default ("anthropic"). If the routing
+        handler swallows LLMResolvedCallError and retries via fallback_provider, the
+        assertion ``r.provider == "google"`` fails (it would be "anthropic" instead),
+        exposing the bug. With routed_provider="anthropic" (the old value), the test
+        passed coincidentally because both paths produce the same identity.
 
         Lowest allowed mock seam: ``_invoke_with_resilience_async``.
         Forbidden: ``call_llm_async`` (mocks out routing where identity is resolved).
         """
-        # Spec with provider=None triggers routing; routing resolves to anthropic:claude-haiku.
+        # Spec with provider=None triggers routing; routing resolves to google:gemini-pro.
+        # "google" is intentionally different from the routing fallback default "anthropic".
         spec = LLMCallSpec(
             spec_id="routed-fail",
             messages=[{"role": "user", "content": "hello"}],
@@ -1147,7 +1155,7 @@ class TestAC008FailureNormalizationRound2(unittest.IsolatedAsyncioTestCase):
             routing_context={"routing_enabled": True, "task_type": "general"},
         )
         service = self._make_routed_service(
-            routed_provider="anthropic", routed_model="claude-haiku"
+            routed_provider="google", routed_model="gemini-pro"
         )
 
         from agentmap.exceptions.service_exceptions import LLMProviderError
@@ -1168,12 +1176,14 @@ class TestAC008FailureNormalizationRound2(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(r.status, "failed")
         self.assertEqual(
             r.provider,
-            "anthropic",
-            "provider must be the routing-resolved provider, not spec.provider=None",
+            "google",
+            "provider must be the routing-resolved provider 'google', not the "
+            "fallback default 'anthropic' — if this is 'anthropic', the routing "
+            "handler is swallowing LLMResolvedCallError and re-routing",
         )
         self.assertEqual(
             r.model,
-            "claude-haiku",
+            "gemini-pro",
             "model must be the routing-resolved model, not spec.model=None",
         )
         self.assertIsNotNone(r.error)
@@ -1185,23 +1195,31 @@ class TestAC008FailureNormalizationRound2(unittest.IsolatedAsyncioTestCase):
 
         Counter-factual: against the pre-round-2 code, the bare ``except Exception``
         block uses ``spec.provider`` (e.g., "openai") and the assertion
-        ``r.provider == <last-tier-provider>`` FAILS when fallback selects a different
-        provider.
+        ``r.provider == "google"`` FAILS (would be "openai" instead).
+
+        Three-tier exhaustion (round-3 UAT fix): wires three providers so
+        _try_tier3_fallback_async actually runs. The tier-3 helper skips
+        original_provider ("openai") and configured_fallback_provider ("anthropic"),
+        so "google" is the only provider tier-3 can select. Asserting
+        r.provider == "google" proves tier 3 actually executed.
 
         Lowest allowed mock seam: ``_invoke_with_resilience_async``.
         Forbidden: ``call_llm_async`` (mocks out the fallback ladder).
         """
         mock_features_registry = Mock()
         mock_features_registry.is_provider_available.return_value = True
+        # Three providers: openai (original), anthropic (tier-2 fallback), google (tier-3).
         mock_features_registry.get_available_providers.return_value = [
             "openai",
             "anthropic",
+            "google",
         ]
         mock_routing_config = Mock()
         mock_routing_config.fallback = {"default_provider": "anthropic"}
         mock_routing_config.routing_matrix = {
             "anthropic": {"low": "claude-haiku"},
             "openai": {"low": "gpt-3.5-turbo"},
+            "google": {"low": "gemini-flash"},
         }
 
         service = LLMService(
@@ -1245,17 +1263,165 @@ class TestAC008FailureNormalizationRound2(unittest.IsolatedAsyncioTestCase):
         r = results[0]
         self.assertEqual(r.spec_id, "fallback-exhaust")
         self.assertEqual(r.status, "failed")
-        # The result must not simply echo spec.provider — it must reflect the last
-        # tier actually attempted (which the fallback handler knows).
-        self.assertIsNotNone(
+        # Tier 3 is the last tier — it selects "google" (skipping "openai" and
+        # "anthropic"). r.provider must be "google", not spec.provider="openai".
+        # If this is "openai", the fallback ladder identity is not propagating.
+        # If this is "anthropic", tier-3 isn't running (only 2-provider test issue).
+        self.assertEqual(
             r.provider,
-            "provider must not be None — a concrete provider was attempted",
+            "google",
+            "provider must be 'google' (tier-3 provider) — not 'openai' (spec.provider) "
+            "and not 'anthropic' (tier-2 provider). 'openai' means last_attempted is "
+            "not propagating. 'anthropic' means tier-3 never executed.",
         )
-        self.assertIsNotNone(
+        self.assertEqual(
             r.model,
-            "model must not be None — a concrete model was attempted",
+            "gemini-flash",
+            "model must be 'gemini-flash' (tier-3 google's fallback model from routing_matrix)",
         )
         self.assertIsNotNone(r.error)
+
+    async def test_tc_ac8_06_routed_failure_must_not_rewrite_identity(self):
+        """TC-AC8-06 (NEW — round-3): routed post-resolution failure MUST NOT be
+        swallowed by routing's broad except-Exception and rewritten with the
+        fallback-provider identity.
+
+        Counter-factual: against pre-fix code, _call_llm_async_with_routing catches
+        LLMResolvedCallError from the routed call (line 786 'except Exception'), logs
+        it as "Routing failed", then re-attempts via fallback_provider="anthropic".
+        That second attempt also raises (same mock), producing a NEW
+        LLMResolvedCallError("anthropic", ...). The fan-out result would have
+        r.provider == "anthropic" instead of the originally-routed "google", and
+        this assertion FAILS.
+
+        After fix (except LLMResolvedCallError: raise inserted before except Exception):
+        the routed LLMResolvedCallError propagates intact with provider="google".
+
+        Lowest allowed mock seam: ``_invoke_with_resilience_async``.
+        Forbidden: ``call_llm_async`` (mocks out routing where identity is resolved).
+        """
+        # Spec with provider=None triggers routing; routing resolves to google:gemini-pro.
+        # Crucially, "google" != routing fallback default "anthropic" — so the swallow-
+        # and-retry path would produce a DIFFERENT provider identity.
+        spec = LLMCallSpec(
+            spec_id="routed-fail-no-rewrite",
+            messages=[{"role": "user", "content": "hello"}],
+            provider=None,
+            routing_context={"routing_enabled": True, "task_type": "general"},
+        )
+        service = self._make_routed_service(
+            routed_provider="google", routed_model="gemini-pro"
+        )
+
+        from agentmap.exceptions.service_exceptions import LLMProviderError
+
+        with patch.object(
+            service,
+            "_invoke_with_resilience_async",
+            new=AsyncMock(
+                side_effect=LLMProviderError("provider failure after routing resolved")
+            ),
+        ):
+            results = await service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.spec_id, "routed-fail-no-rewrite")
+        self.assertEqual(r.status, "failed")
+        self.assertEqual(
+            r.provider,
+            "google",
+            "provider must be 'google' (the routing-resolved provider). "
+            "If 'anthropic', the routing handler swallowed LLMResolvedCallError "
+            "and re-routed to the fallback provider — fix #1 is not in place.",
+        )
+        self.assertEqual(
+            r.model,
+            "gemini-pro",
+            "model must be the routing-resolved model 'gemini-pro'",
+        )
+        self.assertIsNotNone(r.error)
+        self.assertEqual(
+            r.error.error_type,
+            "LLMProviderError",
+            "error_type must preserve the original typed error discriminator",
+        )
+
+    async def test_tc_ac8_07_fallback_exhaustion_typed_cause_preserved(self):
+        """TC-AC8-07 (new — codex MEDIUM-1 regression guard): when all fallback tiers
+        fail with a typed error (e.g., LLMTimeoutError), the fan-out result's
+        error_type must reflect the last tier's typed error, NOT a synthetic
+        LLMServiceError wrapper.
+
+        Counter-factual: against pre-fix code (exhaustion wraps with
+        LLMServiceError(error_msg)), r.error.error_type == "LLMServiceError".
+        After fix (.cause = last_error from the last tier's typed exception),
+        r.error.error_type reflects the actual error class.
+
+        Lowest allowed mock seam: ``_invoke_with_resilience_async``.
+        """
+        from agentmap.exceptions.service_exceptions import LLMTimeoutError
+
+        mock_features_registry = Mock()
+        mock_features_registry.is_provider_available.return_value = True
+        mock_features_registry.get_available_providers.return_value = [
+            "openai",
+            "anthropic",
+            "google",
+        ]
+        mock_routing_config = Mock()
+        mock_routing_config.fallback = {"default_provider": "anthropic"}
+        mock_routing_config.routing_matrix = {
+            "anthropic": {"low": "claude-haiku"},
+            "openai": {"low": "gpt-3.5-turbo"},
+            "google": {"low": "gemini-flash"},
+        }
+
+        service = LLMService(
+            configuration=MockServiceFactory.create_mock_app_config_service(),
+            logging_service=MockServiceFactory.create_mock_logging_service(),
+            routing_service=Mock(),
+            llm_models_config_service=MockServiceFactory.create_mock_llm_models_config_service(),
+            features_registry_service=mock_features_registry,
+            routing_config_service=mock_routing_config,
+        )
+        service._resilience_config = {
+            "retry": {
+                "max_attempts": 1,
+                "backoff_base": 2.0,
+                "backoff_max": 30.0,
+                "jitter": False,
+            },
+            "circuit_breaker": {"failure_threshold": 5, "reset_timeout": 60},
+        }
+        service._provider_utils.normalize_provider = Mock(side_effect=lambda p: p)
+        service._provider_utils.get_provider_config = Mock(
+            side_effect=lambda p: {"model": f"{p}-default", "api_key": "test"}
+        )
+        service._message_utils.convert_messages_to_langchain = Mock(
+            return_value=[Mock()]
+        )
+        service._client_factory.get_or_create_client = Mock(return_value=Mock())
+
+        spec = _make_spec("typed-cause-exhaust", provider="openai", model="gpt-4o")
+
+        with patch.object(
+            service,
+            "_invoke_with_resilience_async",
+            new=AsyncMock(side_effect=LLMTimeoutError("request timed out")),
+        ):
+            results = await service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.status, "failed")
+        self.assertIsNotNone(r.error)
+        self.assertEqual(
+            r.error.error_type,
+            "LLMTimeoutError",
+            "error_type must be 'LLMTimeoutError' (last tier's typed error). "
+            "If 'LLMServiceError', the fallback exhaustion path wrapped with a "
+            "synthetic LLMServiceError, losing the typed discriminator — "
+            "fix MEDIUM-1 is not in place.",
+        )
 
     async def test_tc_ac8_02_non_fabrication_invariant_preserved(self):
         """TC-AC8-02 invariant: when failure occurs before any resolution
@@ -1288,6 +1454,114 @@ class TestAC008FailureNormalizationRound2(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.service = _make_service()
+
+
+# ---------------------------------------------------------------------------
+# TC-AC8-08: LLMResolvedCallError propagation through telemetry wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestLLMResolvedCallErrorTelemetryPropagation(unittest.IsolatedAsyncioTestCase):
+    """TC-AC8-08 (new — codex LOW-2): LLMResolvedCallError propagates unchanged
+    through the telemetry-wrapped call_llm_async path.
+
+    Code review confirmed the telemetry wrapper re-raises LLMServiceError subclasses
+    at llm_service.py:343-352. This test is a regression guard — if the isinstance
+    check is accidentally removed or narrowed, this test will fail.
+
+    Seam: patch ``_invoke_with_resilience_async`` (lowest allowed).
+    Wires a real telemetry service stub so the telemetry path is exercised.
+    """
+
+    def _make_service_with_telemetry(self) -> LLMService:
+        """Build a service with a stub telemetry service wired in."""
+        mock_logging = MockServiceFactory.create_mock_logging_service()
+        mock_config = MockServiceFactory.create_mock_app_config_service()
+        mock_config.get_llm_resilience_config.return_value = {
+            "retry": {
+                "max_attempts": 1,
+                "backoff_base": 2.0,
+                "backoff_max": 30.0,
+                "jitter": False,
+            },
+            "circuit_breaker": {"failure_threshold": 5, "reset_timeout": 60},
+        }
+        mock_config.get_llm_config.side_effect = lambda provider: {
+            "model": f"{provider}-default-model",
+            "api_key": "test-key",
+        }
+        mock_models = MockServiceFactory.create_mock_llm_models_config_service()
+        mock_routing = Mock()
+
+        # Minimal telemetry stub: start_span returns a context manager; metrics
+        # return Mocks so _record_* helpers don't throw.
+        mock_telemetry = Mock()
+        mock_span = Mock()
+        mock_span.__enter__ = Mock(return_value=mock_span)
+        mock_span.__exit__ = Mock(return_value=False)
+        mock_telemetry.start_span.return_value = mock_span
+        mock_telemetry.create_histogram.return_value = Mock()
+        mock_telemetry.create_counter.return_value = Mock()
+        mock_telemetry.create_up_down_counter.return_value = Mock()
+
+        service = LLMService(
+            configuration=mock_config,
+            logging_service=mock_logging,
+            routing_service=mock_routing,
+            llm_models_config_service=mock_models,
+            telemetry_service=mock_telemetry,
+        )
+        service._provider_utils.normalize_provider = Mock(side_effect=lambda p: p)
+        service._provider_utils.get_provider_config = Mock(
+            return_value={"model": "claude-haiku", "api_key": "test"}
+        )
+        service._message_utils.convert_messages_to_langchain = Mock(
+            return_value=[Mock()]
+        )
+        service._client_factory.get_or_create_client = Mock(return_value=Mock())
+        return service
+
+    async def test_tc_ac8_08_resolved_call_error_propagates_through_telemetry_wrapper(
+        self,
+    ):
+        """TC-AC8-08: call_llm_async (telemetry path) propagates LLMResolvedCallError
+        with all three attributes intact.
+
+        Counter-factual: if the telemetry wrapper's except-clause catches
+        LLMResolvedCallError and re-wraps or swallows it, callers cannot read
+        .resolved_provider / .resolved_model / .cause — this assertion fails.
+
+        Lowest allowed mock seam: ``_invoke_with_resilience_async``.
+        """
+        from agentmap.exceptions.service_exceptions import LLMProviderError
+
+        service = self._make_service_with_telemetry()
+
+        underlying = LLMProviderError("provider timeout")
+        resolved_err = LLMResolvedCallError(
+            resolved_provider="anthropic",
+            resolved_model="claude-haiku",
+            cause=underlying,
+        )
+
+        with patch.object(
+            service,
+            "_invoke_with_resilience_async",
+            new=AsyncMock(side_effect=resolved_err),
+        ):
+            with self.assertRaises(LLMResolvedCallError) as ctx:
+                await service.call_llm_async(
+                    messages=[{"role": "user", "content": "hello"}],
+                    provider="anthropic",
+                    model="claude-haiku",
+                )
+
+        exc = ctx.exception
+        self.assertIsInstance(exc, LLMResolvedCallError)
+        self.assertIsInstance(exc, LLMServiceError)
+        self.assertEqual(exc.resolved_provider, "anthropic")
+        self.assertEqual(exc.resolved_model, "claude-haiku")
+        self.assertIs(exc.cause, underlying)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fresh_suite/unit/services/test_llm_service_fanout.py
+++ b/tests/fresh_suite/unit/services/test_llm_service_fanout.py
@@ -1,0 +1,679 @@
+"""
+Fan-out tests for LLMService.call_llm_many_async.
+
+Covers AC-001 through AC-009 from the E05-F02 test plan:
+  AC-001: Protocol surface (TC-AC1-01, TC-AC1-02)
+  AC-002: One result per spec (TC-AC2-01, TC-AC2-02)
+  AC-003: Stable ordering (TC-AC3-01, TC-AC3-02)
+  AC-004: Submission validation (TC-AC4-01, TC-AC4-02, TC-AC4-03)
+  AC-005: Concurrency cap (TC-AC5-01, TC-AC5-02)
+  AC-006: Partial-failure completion (TC-AC6-01, TC-AC6-02)
+  AC-007: Successful result normalization (TC-AC7-01, TC-AC7-02)
+  AC-008: Failure result normalization (TC-AC8-01, TC-AC8-02)
+  AC-009: Cache-aware request pass-through (TC-AC9-01, TC-AC9-02)
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, Mock, create_autospec, patch
+
+from agentmap.exceptions import LLMServiceError
+from agentmap.models.llm_execution import LLMCallResult, LLMCallSpec, LLMUsage
+from agentmap.services.llm_service import LLMService
+from agentmap.services.protocols import LLMServiceProtocol
+from tests.utils.mock_service_factory import MockServiceFactory
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_spec(spec_id: str, provider: str = "openai", **kwargs) -> LLMCallSpec:
+    """Factory for minimal test LLMCallSpec instances."""
+    return LLMCallSpec(
+        spec_id=spec_id,
+        messages=[{"role": "user", "content": f"prompt for {spec_id}"}],
+        provider=provider,
+        **kwargs,
+    )
+
+
+def _make_service() -> LLMService:
+    """Construct a minimal LLMService with mock dependencies."""
+    mock_logging = MockServiceFactory.create_mock_logging_service()
+    mock_config = MockServiceFactory.create_mock_app_config_service()
+    mock_config.get_llm_resilience_config.return_value = {
+        "retry": {
+            "max_attempts": 1,
+            "backoff_base": 2.0,
+            "backoff_max": 30.0,
+            "jitter": False,
+        },
+        "circuit_breaker": {"failure_threshold": 5, "reset_timeout": 60},
+    }
+    mock_config.get_llm_config.side_effect = lambda provider: {
+        "model": f"{provider}-default-model",
+        "api_key": "test-key",
+    }
+    mock_models = MockServiceFactory.create_mock_llm_models_config_service()
+    mock_routing = Mock()
+
+    return LLMService(
+        configuration=mock_config,
+        logging_service=mock_logging,
+        routing_service=mock_routing,
+        llm_models_config_service=mock_models,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-001  Protocol surface
+# ---------------------------------------------------------------------------
+
+
+class TestAC001ProtocolSurface(unittest.TestCase):
+    """TC-AC1-01 and TC-AC1-02: protocol and concrete service surface."""
+
+    def test_tc_ac1_01_protocol_autospec_exposes_fan_out_method(self):
+        """TC-AC1-01: autospec exposes call_llm_many_async as an AsyncMock."""
+        mock_service = create_autospec(LLMServiceProtocol, instance=True)
+
+        self.assertTrue(hasattr(mock_service, "call_llm_many_async"))
+        self.assertIsInstance(mock_service.call_llm_many_async, AsyncMock)
+
+    def test_tc_ac1_01_protocol_autospec_preserves_existing_methods(self):
+        """TC-AC1-01: existing protocol members are not removed."""
+        mock_service = create_autospec(LLMServiceProtocol, instance=True)
+
+        self.assertTrue(hasattr(mock_service, "call_llm"))
+        self.assertTrue(hasattr(mock_service, "call_llm_async"))
+        self.assertTrue(hasattr(mock_service, "ask_async"))
+        self.assertTrue(hasattr(mock_service, "ask_vision"))
+
+    def test_tc_ac1_02_concrete_service_exposes_fan_out_method(self):
+        """TC-AC1-02: LLMService instance has callable call_llm_many_async."""
+        service = _make_service()
+
+        self.assertTrue(hasattr(service, "call_llm_many_async"))
+        self.assertTrue(callable(service.call_llm_many_async))
+
+    def test_tc_ac1_02_concrete_service_preserves_existing_public_methods(self):
+        """TC-AC1-02: additive — existing public methods remain available."""
+        service = _make_service()
+
+        for method in ("call_llm", "call_llm_async", "ask_async", "ask", "ask_vision"):
+            self.assertTrue(hasattr(service, method), f"missing method: {method}")
+
+
+# ---------------------------------------------------------------------------
+# AC-002  One result per spec
+# ---------------------------------------------------------------------------
+
+
+class TestAC002OneResultPerSpec(unittest.IsolatedAsyncioTestCase):
+    """TC-AC2-01 and TC-AC2-02: exactly one terminal result per submitted spec."""
+
+    def setUp(self):
+        self.service = _make_service()
+
+    async def test_tc_ac2_01_three_specs_return_three_results(self):
+        """TC-AC2-01: 3 specs submitted yields exactly 3 terminal results."""
+        specs = [_make_spec(f"spec-{i}") for i in range(3)]
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(return_value="response"),
+        ):
+            results = await self.service.call_llm_many_async(specs, max_concurrency=2)
+
+        self.assertEqual(len(results), 3)
+        for result in results:
+            self.assertIsInstance(result, LLMCallResult)
+            self.assertEqual(result.status, "succeeded")
+
+    async def test_tc_ac2_01_single_spec_returns_single_result(self):
+        """TC-AC2-01 edge: single-item submission returns one result."""
+        specs = [_make_spec("only-one")]
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(return_value="hello"),
+        ):
+            results = await self.service.call_llm_many_async(specs, max_concurrency=1)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].spec_id, "only-one")
+        self.assertEqual(results[0].content, "hello")
+
+    async def test_tc_ac2_02_large_submission_has_no_dropped_or_duplicated_results(
+        self,
+    ):
+        """TC-AC2-02: 100 specs with concurrency=8 yield exactly 100 results."""
+        specs = [_make_spec(f"bulk-{i}") for i in range(100)]
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(return_value="ok"),
+        ):
+            results = await self.service.call_llm_many_async(specs, max_concurrency=8)
+
+        self.assertEqual(len(results), 100)
+        returned_ids = [r.spec_id for r in results]
+        self.assertEqual(len(set(returned_ids)), 100)
+        for spec in specs:
+            self.assertIn(spec.spec_id, returned_ids)
+
+
+# ---------------------------------------------------------------------------
+# AC-003  Stable ordering
+# ---------------------------------------------------------------------------
+
+
+class TestAC003StableOrdering(unittest.IsolatedAsyncioTestCase):
+    """TC-AC3-01 and TC-AC3-02: output order matches input order."""
+
+    def setUp(self):
+        self.service = _make_service()
+
+    async def test_tc_ac3_01_results_preserve_input_order_despite_completion_delay(
+        self,
+    ):
+        """TC-AC3-01: completion order B,C,A should not affect output order A,B,C."""
+        call_count = [0]
+
+        async def ordered_response(*args, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            # Simulate: spec_b finishes quickly, spec_c next, spec_a last
+            delays = [0.02, 0.00, 0.01]
+            await asyncio.sleep(delays[idx])
+            return f"response-{idx}"
+
+        specs = [_make_spec("spec-a"), _make_spec("spec-b"), _make_spec("spec-c")]
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(side_effect=ordered_response),
+        ):
+            results = await self.service.call_llm_many_async(specs, max_concurrency=3)
+
+        self.assertEqual(len(results), 3)
+        self.assertEqual(results[0].spec_id, "spec-a")
+        self.assertEqual(results[1].spec_id, "spec-b")
+        self.assertEqual(results[2].spec_id, "spec-c")
+
+    async def test_tc_ac3_02_each_result_carries_original_spec_id(self):
+        """TC-AC3-02: each result's spec_id matches its originating spec."""
+        specs = [_make_spec("id-first"), _make_spec("id-second")]
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(return_value="content"),
+        ):
+            results = await self.service.call_llm_many_async(specs, max_concurrency=2)
+
+        self.assertEqual(results[0].spec_id, "id-first")
+        self.assertEqual(results[1].spec_id, "id-second")
+
+
+# ---------------------------------------------------------------------------
+# AC-004  Submission validation
+# ---------------------------------------------------------------------------
+
+
+class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
+    """TC-AC4-01, TC-AC4-02, TC-AC4-03: validation before execution."""
+
+    def setUp(self):
+        self.service = _make_service()
+
+    async def test_tc_ac4_01_empty_call_specs_raises_before_execution(self):
+        """TC-AC4-01: empty call_specs must raise LLMServiceError."""
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
+            with self.assertRaises(LLMServiceError):
+                await self.service.call_llm_many_async([], max_concurrency=1)
+
+            mock_call.assert_not_called()
+
+    async def test_tc_ac4_02_duplicate_spec_id_raises_before_execution(self):
+        """TC-AC4-02: duplicate spec_id raises LLMServiceError before execution."""
+        specs = [_make_spec("dup-1"), _make_spec("dup-1")]
+
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
+            with self.assertRaises(LLMServiceError):
+                await self.service.call_llm_many_async(specs, max_concurrency=2)
+
+            mock_call.assert_not_called()
+
+    async def test_tc_ac4_02_duplicate_spec_id_separated_in_large_list(self):
+        """TC-AC4-02 edge: duplicates separated in a large list are still caught."""
+        specs = [_make_spec(f"item-{i}") for i in range(20)]
+        specs.append(_make_spec("item-5"))  # duplicate at the end
+
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
+            with self.assertRaises(LLMServiceError):
+                await self.service.call_llm_many_async(specs, max_concurrency=4)
+
+            mock_call.assert_not_called()
+
+    async def test_tc_ac4_03_zero_concurrency_raises_before_execution(self):
+        """TC-AC4-03: max_concurrency=0 raises LLMServiceError."""
+        specs = [_make_spec("one")]
+
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
+            with self.assertRaises(LLMServiceError):
+                await self.service.call_llm_many_async(specs, max_concurrency=0)
+
+            mock_call.assert_not_called()
+
+    async def test_tc_ac4_03_negative_concurrency_raises_before_execution(self):
+        """TC-AC4-03 edge: max_concurrency=-1 raises LLMServiceError."""
+        specs = [_make_spec("one")]
+
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
+            with self.assertRaises(LLMServiceError):
+                await self.service.call_llm_many_async(specs, max_concurrency=-1)
+
+            mock_call.assert_not_called()
+
+    async def test_tc_ac4_03_concurrency_of_one_is_accepted_boundary(self):
+        """TC-AC4-03 BVA: max_concurrency=1 is the valid lower boundary."""
+        specs = [_make_spec("solo")]
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(return_value="ok"),
+        ):
+            results = await self.service.call_llm_many_async(specs, max_concurrency=1)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].status, "succeeded")
+
+
+# ---------------------------------------------------------------------------
+# AC-005  Concurrency cap
+# ---------------------------------------------------------------------------
+
+
+class TestAC005ConcurrencyCap(unittest.IsolatedAsyncioTestCase):
+    """TC-AC5-01 and TC-AC5-02: never exceed caller-supplied concurrency cap."""
+
+    def setUp(self):
+        self.service = _make_service()
+
+    async def test_tc_ac5_01_observed_max_in_flight_never_exceeds_cap(self):
+        """TC-AC5-01: real-time in-flight count never exceeds max_concurrency=2."""
+        cap = 2
+        in_flight = [0]
+        max_observed = [0]
+
+        async def probe(*args, **kwargs):
+            in_flight[0] += 1
+            max_observed[0] = max(max_observed[0], in_flight[0])
+            await asyncio.sleep(0.01)
+            in_flight[0] -= 1
+            return "ok"
+
+        specs = [_make_spec(f"s{i}") for i in range(5)]
+
+        with patch.object(
+            self.service, "call_llm_async", new=AsyncMock(side_effect=probe)
+        ):
+            results = await self.service.call_llm_many_async(specs, max_concurrency=cap)
+
+        self.assertLessEqual(max_observed[0], cap)
+        self.assertEqual(len(results), 5)
+
+    async def test_tc_ac5_01_sequential_cap_is_enforced(self):
+        """TC-AC5-01 edge: max_concurrency=1 ensures fully sequential execution."""
+        call_order = []
+
+        async def record_call(*args, **kwargs):
+            spec_id = kwargs.get("messages", [{}])[0].get("content", "?")
+            call_order.append(spec_id)
+            return "ok"
+
+        specs = [_make_spec(f"seq-{i}") for i in range(3)]
+
+        with patch.object(
+            self.service, "call_llm_async", new=AsyncMock(side_effect=record_call)
+        ):
+            await self.service.call_llm_many_async(specs, max_concurrency=1)
+
+        # All 3 must have been called exactly once, sequentially
+        self.assertEqual(len(call_order), 3)
+
+    async def test_tc_ac5_02_different_caps_do_not_change_result_correctness(self):
+        """TC-AC5-02: changing cap changes parallelism but not result content."""
+        specs = [_make_spec(f"item-{i}") for i in range(4)]
+
+        async def echo(*args, **kwargs):
+            messages = kwargs.get("messages", [])
+            return messages[0]["content"] if messages else "?"
+
+        with patch.object(
+            self.service, "call_llm_async", new=AsyncMock(side_effect=echo)
+        ):
+            results_1 = await self.service.call_llm_many_async(specs, max_concurrency=1)
+
+        with patch.object(
+            self.service, "call_llm_async", new=AsyncMock(side_effect=echo)
+        ):
+            results_3 = await self.service.call_llm_many_async(specs, max_concurrency=3)
+
+        ids_1 = [r.spec_id for r in results_1]
+        ids_3 = [r.spec_id for r in results_3]
+        self.assertEqual(ids_1, ids_3)
+
+
+# ---------------------------------------------------------------------------
+# AC-006  Partial-failure completion semantics
+# ---------------------------------------------------------------------------
+
+
+class TestAC006PartialFailure(unittest.IsolatedAsyncioTestCase):
+    """TC-AC6-01 and TC-AC6-02: one failure must not abort siblings."""
+
+    def setUp(self):
+        self.service = _make_service()
+
+    async def test_tc_ac6_01_mixed_success_and_failure_returns_all_results(self):
+        """TC-AC6-01: 3 specs with middle failing returns 3 terminal records."""
+        specs = [_make_spec("ok-a"), _make_spec("fail-b"), _make_spec("ok-c")]
+
+        async def mixed_response(*args, **kwargs):
+            messages = kwargs.get("messages", [])
+            content = messages[0]["content"] if messages else ""
+            if "fail-b" in content:
+                raise RuntimeError("provider error")
+            return "success"
+
+        with patch.object(
+            self.service, "call_llm_async", new=AsyncMock(side_effect=mixed_response)
+        ):
+            results = await self.service.call_llm_many_async(specs, max_concurrency=3)
+
+        self.assertEqual(len(results), 3)
+        statuses = {r.spec_id: r.status for r in results}
+        self.assertEqual(statuses["ok-a"], "succeeded")
+        self.assertEqual(statuses["fail-b"], "failed")
+        self.assertEqual(statuses["ok-c"], "succeeded")
+
+    async def test_tc_ac6_01_submission_does_not_raise_after_item_failure(self):
+        """TC-AC6-01: call_llm_many_async itself must not re-raise item exceptions."""
+        specs = [_make_spec("always-fail")]
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            # Must not raise — returns a failure result instead
+            results = await self.service.call_llm_many_async(specs, max_concurrency=1)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].status, "failed")
+
+    async def test_tc_ac6_02_slow_sibling_completes_after_fast_failure(self):
+        """TC-AC6-02: slow success sibling still completes after fast failure."""
+        specs = [_make_spec("fast-fail"), _make_spec("slow-ok")]
+
+        async def behavior(*args, **kwargs):
+            messages = kwargs.get("messages", [])
+            content = messages[0]["content"] if messages else ""
+            if "fast-fail" in content:
+                raise RuntimeError("fast error")
+            await asyncio.sleep(0.02)
+            return "slow result"
+
+        with patch.object(
+            self.service, "call_llm_async", new=AsyncMock(side_effect=behavior)
+        ):
+            results = await self.service.call_llm_many_async(specs, max_concurrency=2)
+
+        self.assertEqual(len(results), 2)
+        statuses = {r.spec_id: r.status for r in results}
+        self.assertEqual(statuses["fast-fail"], "failed")
+        self.assertEqual(statuses["slow-ok"], "succeeded")
+        self.assertEqual(results[1].content, "slow result")
+
+
+# ---------------------------------------------------------------------------
+# AC-007  Successful result normalization
+# ---------------------------------------------------------------------------
+
+
+class TestAC007SuccessNormalization(unittest.IsolatedAsyncioTestCase):
+    """TC-AC7-01 and TC-AC7-02: normalized fields on successful results."""
+
+    def setUp(self):
+        self.service = _make_service()
+
+    async def test_tc_ac7_01_succeeded_result_has_spec_id_status_and_content(self):
+        """TC-AC7-01: successful result carries spec_id, status=succeeded, content."""
+        spec = _make_spec("result-check", provider="openai", model="gpt-4o-mini")
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(return_value="great answer"),
+        ):
+            results = await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.spec_id, "result-check")
+        self.assertEqual(r.status, "succeeded")
+        self.assertEqual(r.content, "great answer")
+
+    async def test_tc_ac7_01_succeeded_result_carries_provider_and_model(self):
+        """TC-AC7-01: provider and model from the spec appear on the result."""
+        spec = _make_spec("prov-check", provider="anthropic", model="claude-3-haiku")
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(return_value="reply"),
+        ):
+            results = await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.provider, "anthropic")
+        self.assertEqual(r.model, "claude-3-haiku")
+
+
+# ---------------------------------------------------------------------------
+# AC-008  Failure result normalization
+# ---------------------------------------------------------------------------
+
+
+class TestAC008FailureNormalization(unittest.IsolatedAsyncioTestCase):
+    """TC-AC8-01 and TC-AC8-02: structured error payload on failed results."""
+
+    def setUp(self):
+        self.service = _make_service()
+
+    async def test_tc_ac8_01_provider_exception_becomes_structured_failure(self):
+        """TC-AC8-01: exception from async path yields structured LLMExecutionError."""
+        spec = _make_spec("fail-me")
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(side_effect=RuntimeError("Connection timeout")),
+        ):
+            results = await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.spec_id, "fail-me")
+        self.assertEqual(r.status, "failed")
+        self.assertIsNotNone(r.error)
+        self.assertIsInstance(r.error.error_type, str)
+        self.assertIsInstance(r.error.message, str)
+        self.assertIn("Connection timeout", r.error.message)
+
+    async def test_tc_ac8_02_failed_result_spec_id_is_preserved(self):
+        """TC-AC8-02: spec_id is always present on the failure record."""
+        spec = _make_spec("id-must-survive")
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(side_effect=ValueError("routing failed")),
+        ):
+            results = await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+        self.assertEqual(results[0].spec_id, "id-must-survive")
+
+    async def test_tc_ac8_02_unknown_provider_failure_does_not_fabricate_provider(self):
+        """TC-AC8-02: provider=None spec stays None on failure, not a placeholder."""
+        spec = LLMCallSpec(
+            spec_id="no-provider",
+            messages=[{"role": "user", "content": "hi"}],
+            provider=None,
+            routing_context={"routing_enabled": True},
+        )
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(side_effect=RuntimeError("routing error")),
+        ):
+            results = await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.status, "failed")
+        self.assertIsNone(r.provider)
+
+
+# ---------------------------------------------------------------------------
+# AC-009  Cache-aware request pass-through
+# ---------------------------------------------------------------------------
+
+
+class TestAC009CacheAwarePassThrough(unittest.IsolatedAsyncioTestCase):
+    """TC-AC9-01 and TC-AC9-02: cache-aware fields survive the fan-out layer."""
+
+    def setUp(self):
+        self.service = _make_service()
+
+    async def test_tc_ac9_01_messages_and_request_options_reach_call_llm_async(self):
+        """TC-AC9-01: messages and request_options from spec are forwarded unchanged."""
+        structured_messages = [
+            {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+        ]
+        cache_options = {"requires_prompt_caching": True, "cache_mode": "ephemeral"}
+        spec = LLMCallSpec(
+            spec_id="cache-spec",
+            messages=structured_messages,
+            provider="anthropic",
+            request_options=cache_options,
+        )
+
+        captured_kwargs = {}
+
+        async def capture_call(**kwargs):
+            captured_kwargs.update(kwargs)
+            return "cached response"
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(side_effect=capture_call),
+        ):
+            results = await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+        # messages passed through unchanged
+        self.assertEqual(captured_kwargs.get("messages"), structured_messages)
+        # cache-aware request_options are forwarded as kwargs
+        self.assertTrue(captured_kwargs.get("requires_prompt_caching"))
+        self.assertEqual(results[0].status, "succeeded")
+
+    async def test_tc_ac9_02_unsupported_cache_failure_captured_as_item_error(self):
+        """TC-AC9-02: unsupported cache mode error is captured as failure record."""
+        specs = [
+            _make_spec("ok-sibling"),
+            LLMCallSpec(
+                spec_id="bad-cache",
+                messages=[{"role": "user", "content": "hi"}],
+                provider="openai",
+                request_options={"requires_prompt_caching": True},
+            ),
+        ]
+
+        async def raise_for_cache(**kwargs):
+            if kwargs.get("requires_prompt_caching"):
+                raise LLMServiceError("Provider does not support prompt caching")
+            return "ok"
+
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(side_effect=raise_for_cache),
+        ):
+            results = await self.service.call_llm_many_async(specs, max_concurrency=2)
+
+        statuses = {r.spec_id: r.status for r in results}
+        self.assertEqual(statuses["ok-sibling"], "succeeded")
+        self.assertEqual(statuses["bad-cache"], "failed")
+
+
+# ---------------------------------------------------------------------------
+# _extract_llm_usage helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLlmUsage(unittest.TestCase):
+    """Unit tests for the _extract_llm_usage normalizer."""
+
+    def test_returns_none_when_no_usage_metadata(self):
+        response = Mock(spec=[])  # no usage_metadata attribute
+        result = LLMService._extract_llm_usage(response)
+        self.assertIsNone(result)
+
+    def test_returns_llm_usage_with_all_fields_from_dict(self):
+        response = Mock()
+        response.usage_metadata = {
+            "input_tokens": 10,
+            "output_tokens": 20,
+            "cache_creation_input_tokens": 5,
+            "cache_read_input_tokens": 3,
+        }
+        result = LLMService._extract_llm_usage(response)
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, LLMUsage)
+        self.assertEqual(result.input_tokens, 10)
+        self.assertEqual(result.output_tokens, 20)
+        self.assertEqual(result.cache_creation_input_tokens, 5)
+        self.assertEqual(result.cache_read_input_tokens, 3)
+
+    def test_absent_cache_fields_remain_none(self):
+        response = Mock()
+        response.usage_metadata = {"input_tokens": 8, "output_tokens": 12}
+        result = LLMService._extract_llm_usage(response)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.input_tokens, 8)
+        self.assertIsNone(result.cache_creation_input_tokens)
+        self.assertIsNone(result.cache_read_input_tokens)
+
+    def test_returns_llm_usage_from_object_with_attributes(self):
+        usage = Mock()
+        usage.input_tokens = 15
+        usage.output_tokens = 25
+        usage.cache_creation_input_tokens = None
+        usage.cache_read_input_tokens = None
+        response = Mock()
+        response.usage_metadata = usage
+        result = LLMService._extract_llm_usage(response)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.input_tokens, 15)
+        self.assertEqual(result.output_tokens, 25)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/fresh_suite/unit/services/test_llm_service_fanout.py
+++ b/tests/fresh_suite/unit/services/test_llm_service_fanout.py
@@ -8,9 +8,15 @@ Covers AC-001 through AC-009 from the E05-F02 test plan:
   AC-004: Submission validation (TC-AC4-01, TC-AC4-02, TC-AC4-03)
   AC-005: Concurrency cap (TC-AC5-01, TC-AC5-02)
   AC-006: Partial-failure completion (TC-AC6-01, TC-AC6-02)
-  AC-007: Successful result normalization (TC-AC7-01, TC-AC7-02)
+  AC-007: Successful result normalization (TC-AC7-01 – TC-AC7-04)
   AC-008: Failure result normalization (TC-AC8-01, TC-AC8-02)
   AC-009: Cache-aware request pass-through (TC-AC9-01, TC-AC9-02)
+
+Seam convention (post-rework):
+  - Tests patch ``_invoke_with_resilience_async`` as the lowest allowed mock seam.
+  - ``call_llm_async`` is the fan-out entry point; ``_call_llm_async_core`` is
+    the single private seam both the public method and fan-out share.
+  - The deleted ``_call_llm_async_with_response`` seam MUST NOT appear here.
 """
 
 import asyncio
@@ -18,7 +24,12 @@ import unittest
 from unittest.mock import AsyncMock, Mock, create_autospec, patch
 
 from agentmap.exceptions import LLMServiceError
-from agentmap.models.llm_execution import LLMCallResult, LLMCallSpec, LLMUsage
+from agentmap.models.llm_execution import (
+    LLMCallResult,
+    LLMCallSpec,
+    LLMResponse,
+    LLMUsage,
+)
 from agentmap.services.llm_service import LLMService
 from agentmap.services.protocols import LLMServiceProtocol
 from tests.utils.mock_service_factory import MockServiceFactory
@@ -63,6 +74,21 @@ def _make_service() -> LLMService:
         logging_service=mock_logging,
         routing_service=mock_routing,
         llm_models_config_service=mock_models,
+    )
+
+
+def _llm_response(
+    text: str,
+    provider: str = "openai",
+    model: str = "openai-default-model",
+    usage: LLMUsage = None,
+) -> LLMResponse:
+    """Build a minimal LLMResponse for test stubs."""
+    return LLMResponse(
+        text=text,
+        resolved_provider=provider,
+        resolved_model=model,
+        usage=usage,
     )
 
 
@@ -122,8 +148,8 @@ class TestAC002OneResultPerSpec(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
-            new=AsyncMock(return_value=("response", None)),
+            "call_llm_async",
+            new=AsyncMock(return_value=_llm_response("response")),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=2)
 
@@ -138,8 +164,8 @@ class TestAC002OneResultPerSpec(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
-            new=AsyncMock(return_value=("hello", None)),
+            "call_llm_async",
+            new=AsyncMock(return_value=_llm_response("hello")),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=1)
 
@@ -155,8 +181,8 @@ class TestAC002OneResultPerSpec(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
-            new=AsyncMock(return_value=("ok", None)),
+            "call_llm_async",
+            new=AsyncMock(return_value=_llm_response("ok")),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=8)
 
@@ -190,13 +216,13 @@ class TestAC003StableOrdering(unittest.IsolatedAsyncioTestCase):
             # Simulate: spec_b finishes quickly, spec_c next, spec_a last
             delays = [0.02, 0.00, 0.01]
             await asyncio.sleep(delays[idx])
-            return f"response-{idx}", None
+            return _llm_response(f"response-{idx}")
 
         specs = [_make_spec("spec-a"), _make_spec("spec-b"), _make_spec("spec-c")]
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=ordered_response),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=3)
@@ -212,8 +238,8 @@ class TestAC003StableOrdering(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
-            new=AsyncMock(return_value=("content", None)),
+            "call_llm_async",
+            new=AsyncMock(return_value=_llm_response("content")),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=2)
 
@@ -235,7 +261,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
     async def test_tc_ac4_01_empty_call_specs_raises_before_execution(self):
         """TC-AC4-01: empty call_specs must raise LLMServiceError."""
         with patch.object(
-            self.service, "_call_llm_async_with_response", new=AsyncMock()
+            self.service, "call_llm_async", new=AsyncMock()
         ) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async([], max_concurrency=1)
@@ -247,7 +273,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         specs = [_make_spec("dup-1"), _make_spec("dup-1")]
 
         with patch.object(
-            self.service, "_call_llm_async_with_response", new=AsyncMock()
+            self.service, "call_llm_async", new=AsyncMock()
         ) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=2)
@@ -260,7 +286,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         specs.append(_make_spec("item-5"))  # duplicate at the end
 
         with patch.object(
-            self.service, "_call_llm_async_with_response", new=AsyncMock()
+            self.service, "call_llm_async", new=AsyncMock()
         ) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=4)
@@ -272,7 +298,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         specs = [_make_spec("one")]
 
         with patch.object(
-            self.service, "_call_llm_async_with_response", new=AsyncMock()
+            self.service, "call_llm_async", new=AsyncMock()
         ) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=0)
@@ -284,7 +310,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         specs = [_make_spec("one")]
 
         with patch.object(
-            self.service, "_call_llm_async_with_response", new=AsyncMock()
+            self.service, "call_llm_async", new=AsyncMock()
         ) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=-1)
@@ -297,13 +323,53 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
-            new=AsyncMock(return_value=("ok", None)),
+            "call_llm_async",
+            new=AsyncMock(return_value=_llm_response("ok")),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=1)
 
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].status, "succeeded")
+
+    async def test_tc_ac4_03_bool_concurrency_is_rejected(self):
+        """LOW-1: max_concurrency=True is rejected even though bool is int subclass."""
+        specs = [_make_spec("one")]
+
+        with patch.object(
+            self.service, "call_llm_async", new=AsyncMock()
+        ) as mock_call:
+            with self.assertRaises(LLMServiceError):
+                await self.service.call_llm_many_async(specs, max_concurrency=True)
+
+            mock_call.assert_not_called()
+
+    async def test_tc_ac4_02_non_string_spec_id_raises_before_execution(self):
+        """MEDIUM-1: spec_id=123 (non-string) raises LLMServiceError before execution."""
+        spec = LLMCallSpec(
+            spec_id=123,  # type: ignore[arg-type]
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        with patch.object(
+            self.service, "call_llm_async", new=AsyncMock()
+        ) as mock_call:
+            with self.assertRaises(LLMServiceError):
+                await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+            mock_call.assert_not_called()
+
+    async def test_tc_ac4_02_empty_string_spec_id_raises_before_execution(self):
+        """MEDIUM-1: spec_id="" (empty string) raises LLMServiceError before execution."""
+        spec = LLMCallSpec(
+            spec_id="",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        with patch.object(
+            self.service, "call_llm_async", new=AsyncMock()
+        ) as mock_call:
+            with self.assertRaises(LLMServiceError):
+                await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+            mock_call.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -328,13 +394,13 @@ class TestAC005ConcurrencyCap(unittest.IsolatedAsyncioTestCase):
             max_observed[0] = max(max_observed[0], in_flight[0])
             await asyncio.sleep(0.01)
             in_flight[0] -= 1
-            return "ok", None
+            return _llm_response("ok")
 
         specs = [_make_spec(f"s{i}") for i in range(5)]
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=probe),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=cap)
@@ -347,20 +413,20 @@ class TestAC005ConcurrencyCap(unittest.IsolatedAsyncioTestCase):
         call_order = []
 
         async def record_call(*args, **kwargs):
-            spec_id = kwargs.get("messages", [{}])[0].get("content", "?")
-            call_order.append(spec_id)
-            return "ok", None
+            messages = kwargs.get("messages", [{}])
+            content = messages[0].get("content", "?") if messages else "?"
+            call_order.append(content)
+            return _llm_response("ok")
 
         specs = [_make_spec(f"seq-{i}") for i in range(3)]
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=record_call),
         ):
             await self.service.call_llm_many_async(specs, max_concurrency=1)
 
-        # All 3 must have been called exactly once, sequentially
         self.assertEqual(len(call_order), 3)
 
     async def test_tc_ac5_02_different_caps_do_not_change_result_correctness(self):
@@ -370,18 +436,18 @@ class TestAC005ConcurrencyCap(unittest.IsolatedAsyncioTestCase):
         async def echo(*args, **kwargs):
             messages = kwargs.get("messages", [])
             text = messages[0]["content"] if messages else "?"
-            return text, None
+            return _llm_response(text)
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=echo),
         ):
             results_1 = await self.service.call_llm_many_async(specs, max_concurrency=1)
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=echo),
         ):
             results_3 = await self.service.call_llm_many_async(specs, max_concurrency=3)
@@ -411,11 +477,11 @@ class TestAC006PartialFailure(unittest.IsolatedAsyncioTestCase):
             content = messages[0]["content"] if messages else ""
             if "fail-b" in content:
                 raise RuntimeError("provider error")
-            return "success", None
+            return _llm_response("success")
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=mixed_response),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=3)
@@ -432,10 +498,9 @@ class TestAC006PartialFailure(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=RuntimeError("boom")),
         ):
-            # Must not raise — returns a failure result instead
             results = await self.service.call_llm_many_async(specs, max_concurrency=1)
 
         self.assertEqual(len(results), 1)
@@ -451,11 +516,11 @@ class TestAC006PartialFailure(unittest.IsolatedAsyncioTestCase):
             if "fast-fail" in content:
                 raise RuntimeError("fast error")
             await asyncio.sleep(0.02)
-            return "slow result", None
+            return _llm_response("slow result")
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=behavior),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=2)
@@ -473,7 +538,7 @@ class TestAC006PartialFailure(unittest.IsolatedAsyncioTestCase):
 
 
 class TestAC007SuccessNormalization(unittest.IsolatedAsyncioTestCase):
-    """TC-AC7-01 and TC-AC7-02: normalized fields on successful results."""
+    """TC-AC7-01 through TC-AC7-04: normalized fields on successful results."""
 
     def setUp(self):
         self.service = _make_service()
@@ -482,12 +547,14 @@ class TestAC007SuccessNormalization(unittest.IsolatedAsyncioTestCase):
         """TC-AC7-01: successful result carries spec_id, status=succeeded, content."""
         spec = _make_spec("result-check", provider="openai", model="gpt-4o-mini")
 
-        # _execute_fan_out_item calls _call_llm_async_with_response (the lower seam)
-        # rather than call_llm_async so that raw response usage is accessible.
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
-            new=AsyncMock(return_value=("great answer", None)),
+            "call_llm_async",
+            new=AsyncMock(
+                return_value=_llm_response(
+                    "great answer", provider="openai", model="gpt-4o-mini"
+                )
+            ),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
 
@@ -496,14 +563,19 @@ class TestAC007SuccessNormalization(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(r.status, "succeeded")
         self.assertEqual(r.content, "great answer")
 
-    async def test_tc_ac7_01_succeeded_result_carries_provider_and_model(self):
-        """TC-AC7-01: provider and model from the spec appear on the result."""
+    async def test_tc_ac7_01_succeeded_result_carries_resolved_provider_and_model(self):
+        """TC-AC7-01: result.provider/model carry resolved values from LLMResponse."""
         spec = _make_spec("prov-check", provider="anthropic", model="claude-3-haiku")
 
+        # Return a response where the resolved provider/model match what was requested
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
-            new=AsyncMock(return_value=("reply", None)),
+            "call_llm_async",
+            new=AsyncMock(
+                return_value=_llm_response(
+                    "reply", provider="anthropic", model="claude-3-haiku"
+                )
+            ),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
 
@@ -512,34 +584,30 @@ class TestAC007SuccessNormalization(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(r.model, "claude-3-haiku")
 
     async def test_tc_ac7_01_full_usage_metadata_is_normalized_onto_result(self):
-        """TC-AC7-01 end-to-end: result.usage carries all token fields from raw response.
+        """TC-AC7-01 end-to-end: result.usage carries all token fields.
 
-        Counter-factual: with usage=None hardcoded, result.usage would be None and
-        the assertions below would fail.  This test MUST fail before the B-1 fix.
+        Counter-factual: if usage is not propagated from LLMResponse, result.usage
+        would be None and the assertions below would fail.
         """
         spec = _make_spec("usage-full", provider="anthropic", model="claude-3-haiku")
 
-        # Construct a fake raw response object that carries usage_metadata with all
-        # four token fields — the same shape a real Anthropic response returns.
-        fake_response = Mock()
-        fake_response.content = "answer with usage"
-        fake_response.usage_metadata = {
-            "input_tokens": 100,
-            "output_tokens": 50,
-            "cache_creation_input_tokens": 20,
-            "cache_read_input_tokens": 10,
-        }
-
-        # Drive via the new _call_llm_async_with_response seam that returns
-        # (text, raw_response).  _execute_fan_out_item calls this seam rather
-        # than call_llm_async so that it can extract usage from the raw response.
-        async def fake_with_response(**kwargs):
-            return ("answer with usage", fake_response)
+        usage = LLMUsage(
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_input_tokens=20,
+            cache_read_input_tokens=10,
+        )
+        llm_resp = LLMResponse(
+            text="answer with usage",
+            resolved_provider="anthropic",
+            resolved_model="claude-3-haiku",
+            usage=usage,
+        )
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
-            new=AsyncMock(side_effect=fake_with_response),
+            "call_llm_async",
+            new=AsyncMock(return_value=llm_resp),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
 
@@ -547,7 +615,7 @@ class TestAC007SuccessNormalization(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(r.status, "succeeded")
         self.assertEqual(r.content, "answer with usage")
         self.assertIsNotNone(
-            r.usage, "result.usage must not be None when usage_metadata is present"
+            r.usage, "result.usage must not be None when LLMResponse.usage is set"
         )
         self.assertIsInstance(r.usage, LLMUsage)
         self.assertEqual(r.usage.input_tokens, 100)
@@ -556,42 +624,222 @@ class TestAC007SuccessNormalization(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(r.usage.cache_read_input_tokens, 10)
 
     async def test_tc_ac7_02_partial_usage_metadata_leaves_absent_fields_as_none(self):
-        """TC-AC7-02 end-to-end: absent cache fields remain None; available fields are set.
+        """TC-AC7-02 end-to-end: absent cache fields remain None; available fields set.
 
-        Counter-factual: with usage=None hardcoded, result.usage would be None
-        and this test would fail.  It MUST fail before the B-1 fix.
+        Counter-factual: if LLMResponse.usage is ignored, result.usage is None.
         """
         spec = _make_spec("usage-partial", provider="openai", model="gpt-4o")
 
-        fake_response = Mock()
-        fake_response.content = "partial usage answer"
-        # Only the base token counts present; cache fields absent.
-        fake_response.usage_metadata = {
-            "input_tokens": 80,
-            "output_tokens": 30,
-        }
-
-        async def fake_with_response(**kwargs):
-            return ("partial usage answer", fake_response)
+        usage = LLMUsage(input_tokens=80, output_tokens=30)
+        llm_resp = LLMResponse(
+            text="partial usage answer",
+            resolved_provider="openai",
+            resolved_model="gpt-4o",
+            usage=usage,
+        )
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
-            new=AsyncMock(side_effect=fake_with_response),
+            "call_llm_async",
+            new=AsyncMock(return_value=llm_resp),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
 
         r = results[0]
         self.assertEqual(r.status, "succeeded")
-        self.assertIsNotNone(
-            r.usage, "result.usage must not be None when usage_metadata is present"
-        )
+        self.assertIsNotNone(r.usage)
         self.assertIsInstance(r.usage, LLMUsage)
         self.assertEqual(r.usage.input_tokens, 80)
         self.assertEqual(r.usage.output_tokens, 30)
-        # Absent fields must remain None rather than being fabricated.
         self.assertIsNone(r.usage.cache_creation_input_tokens)
         self.assertIsNone(r.usage.cache_read_input_tokens)
+
+    async def test_tc_ac7_03_routed_success_returns_resolved_provider_model_and_usage(
+        self,
+    ):
+        """TC-AC7-03: routed success result.provider/model/usage reflect routing decision.
+
+        Counter-factual: if result echoes spec.provider/spec.model instead of resolved
+        values, result.provider == "openai" and result.model == "gpt-4o-mini" would pass
+        but result.provider == "anthropic" would fail.
+
+        Lowest allowed mock seam: ``_invoke_with_resilience_async``.
+        Forbidden: ``_call_llm_async_with_response`` (deleted).
+        """
+        # Spec requests openai/gpt-4o-mini but routing redirects to anthropic.
+        spec = LLMCallSpec(
+            spec_id="routed-item",
+            messages=[{"role": "user", "content": "hello"}],
+            provider="openai",
+            model="gpt-4o-mini",
+            routing_context={"routing_enabled": True, "task_type": "general"},
+        )
+
+        # Mock the routing decision to select anthropic.
+        mock_decision = Mock()
+        mock_decision.provider = "anthropic"
+        mock_decision.model = "claude-haiku"
+        mock_decision.complexity = "low"
+        mock_decision.confidence = 0.9
+        mock_decision.max_tokens = None
+        mock_decision.cache_hit = False
+        mock_decision.fallback_used = False
+        self.service.routing_service.route_request.return_value = mock_decision
+
+        # Stub the provider utils so the direct call resolves.
+        self.service._provider_utils.normalize_provider = Mock(side_effect=lambda p: p)
+        self.service._provider_utils.get_provider_config = Mock(
+            return_value={"model": "claude-haiku", "api_key": "test"}
+        )
+        self.service._provider_utils.get_available_providers = Mock(
+            return_value=["openai", "anthropic"]
+        )
+        self.service._message_utils.extract_prompt_from_messages = Mock(
+            return_value="hello"
+        )
+        self.service._message_utils.convert_messages_to_langchain = Mock(
+            return_value=[Mock()]
+        )
+
+        # Build a fake raw response with usage_metadata.
+        fake_raw_response = Mock()
+        fake_raw_response.content = "routed answer"
+        fake_raw_response.usage_metadata = {
+            "input_tokens": 55,
+            "output_tokens": 15,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 5,
+        }
+        fake_raw_response.response_metadata = {}
+
+        # Stub _invoke_with_resilience_async — the lowest allowed mock seam.
+        # It returns LLMResponse with the resolved provider/model/usage.
+        expected_usage = LLMService._extract_llm_usage(fake_raw_response)
+        expected_response = LLMResponse(
+            text="routed answer",
+            resolved_provider="anthropic",
+            resolved_model="claude-haiku",
+            usage=expected_usage,
+        )
+
+        with patch.object(
+            self.service,
+            "_invoke_with_resilience_async",
+            new=AsyncMock(return_value=expected_response),
+        ):
+            results = await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.status, "succeeded")
+        self.assertEqual(r.content, "routed answer")
+
+        # Result must reflect the routing decision, NOT the spec values.
+        self.assertEqual(
+            r.provider,
+            "anthropic",
+            "provider must be the routed provider, not spec.provider='openai'",
+        )
+        self.assertEqual(
+            r.model,
+            "claude-haiku",
+            "model must be the routed model, not spec.model='gpt-4o-mini'",
+        )
+
+        # Usage must be populated from the routed response.
+        self.assertIsNotNone(r.usage, "usage must be populated for routed success")
+        self.assertEqual(r.usage.input_tokens, 55)
+        self.assertEqual(r.usage.output_tokens, 15)
+        self.assertEqual(r.usage.cache_read_input_tokens, 5)
+
+    async def test_tc_ac7_04_fallback_success_returns_fallback_tier_provider_model_usage(
+        self,
+    ):
+        """TC-AC7-04: fallback success result.provider/model/usage reflect fallback tier.
+
+        Counter-factual: if result echoes spec.provider/spec.model, assertions on
+        the fallback provider/model would fail.
+
+        Lowest allowed mock seam: ``_invoke_with_resilience_async``.
+        Forbidden: ``_call_llm_async_with_response`` (deleted).
+        """
+        spec = _make_spec("fallback-item", provider="openai", model="gpt-4o-mini")
+
+        # Set up fallback handler dependencies.
+        mock_features_registry = Mock()
+        mock_features_registry.is_provider_available.return_value = True
+        mock_routing_config = Mock()
+        mock_routing_config.fallback = {"default_provider": "anthropic"}
+        mock_routing_config.routing_matrix = {
+            "anthropic": {"low": "claude-haiku"},
+            "openai": {"low": "gpt-3.5-turbo"},
+        }
+
+        service = LLMService(
+            configuration=MockServiceFactory.create_mock_app_config_service(),
+            logging_service=MockServiceFactory.create_mock_logging_service(),
+            routing_service=Mock(),
+            llm_models_config_service=MockServiceFactory.create_mock_llm_models_config_service(),
+            features_registry_service=mock_features_registry,
+            routing_config_service=mock_routing_config,
+        )
+        # Configure resilience to 1 attempt so the primary always fails.
+        service._resilience_config = {
+            "retry": {"max_attempts": 1, "backoff_base": 2.0, "backoff_max": 30.0, "jitter": False},
+            "circuit_breaker": {"failure_threshold": 5, "reset_timeout": 60},
+        }
+
+        service._provider_utils.normalize_provider = Mock(side_effect=lambda p: p)
+        service._provider_utils.get_provider_config = Mock(
+            side_effect=lambda p: {"model": f"{p}-default", "api_key": "test"}
+        )
+        service._message_utils.convert_messages_to_langchain = Mock(return_value=[Mock()])
+        service._client_factory.get_or_create_client = Mock(return_value=Mock())
+
+        # _invoke_with_resilience_async fails for openai (primary), succeeds for
+        # anthropic:claude-haiku (tier-1 fallback), returning LLMResponse.
+        fallback_usage = LLMUsage(input_tokens=30, output_tokens=10)
+        fallback_response = LLMResponse(
+            text="fallback answer",
+            resolved_provider="anthropic",
+            resolved_model="claude-haiku",
+            usage=fallback_usage,
+        )
+
+        call_count = [0]
+
+        async def invoke_side_effect(client, msgs, provider, model):
+            call_count[0] += 1
+            if provider == "openai":
+                raise RuntimeError("primary failed")
+            return fallback_response
+
+        with patch.object(
+            service,
+            "_invoke_with_resilience_async",
+            new=AsyncMock(side_effect=invoke_side_effect),
+        ):
+            results = await service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.status, "succeeded")
+        self.assertEqual(r.content, "fallback answer")
+
+        # Must reflect the fallback tier, not spec.provider.
+        self.assertEqual(
+            r.provider,
+            "anthropic",
+            "provider must be the fallback provider, not spec.provider='openai'",
+        )
+        self.assertEqual(
+            r.model,
+            "claude-haiku",
+            "model must be the fallback model",
+        )
+
+        # Usage must be populated from the fallback tier response.
+        self.assertIsNotNone(r.usage, "usage must be populated for fallback success")
+        self.assertEqual(r.usage.input_tokens, 30)
+        self.assertEqual(r.usage.output_tokens, 10)
 
 
 # ---------------------------------------------------------------------------
@@ -611,7 +859,7 @@ class TestAC008FailureNormalization(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=RuntimeError("Connection timeout")),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
@@ -630,7 +878,7 @@ class TestAC008FailureNormalization(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=ValueError("routing failed")),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
@@ -648,7 +896,7 @@ class TestAC008FailureNormalization(unittest.IsolatedAsyncioTestCase):
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=RuntimeError("routing error")),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
@@ -656,6 +904,28 @@ class TestAC008FailureNormalization(unittest.IsolatedAsyncioTestCase):
         r = results[0]
         self.assertEqual(r.status, "failed")
         self.assertIsNone(r.provider)
+
+    async def test_tc_ac8_01_error_message_is_sanitized(self):
+        """LOW-2: error message is sanitized — raw exception detail passed through
+        _sanitize_error_message so any API key-like substring is redacted."""
+        spec = _make_spec("sanitize-me")
+
+        # _sanitize_error_message redacts long opaque token-looking strings.
+        raw_exc = RuntimeError("Error: sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(side_effect=raw_exc),
+        ):
+            results = await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.status, "failed")
+        self.assertNotIn(
+            "sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+            r.error.message,
+            "API key-like token must be redacted from error message",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -686,18 +956,16 @@ class TestAC009CacheAwarePassThrough(unittest.IsolatedAsyncioTestCase):
 
         async def capture_call(**kwargs):
             captured_kwargs.update(kwargs)
-            return "cached response", None
+            return _llm_response("cached response", provider="anthropic")
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=capture_call),
         ):
             results = await self.service.call_llm_many_async([spec], max_concurrency=1)
 
-        # messages passed through unchanged
         self.assertEqual(captured_kwargs.get("messages"), structured_messages)
-        # cache-aware request_options are forwarded as kwargs
         self.assertTrue(captured_kwargs.get("requires_prompt_caching"))
         self.assertEqual(results[0].status, "succeeded")
 
@@ -716,11 +984,11 @@ class TestAC009CacheAwarePassThrough(unittest.IsolatedAsyncioTestCase):
         async def raise_for_cache(**kwargs):
             if kwargs.get("requires_prompt_caching"):
                 raise LLMServiceError("Provider does not support prompt caching")
-            return "ok", None
+            return _llm_response("ok")
 
         with patch.object(
             self.service,
-            "_call_llm_async_with_response",
+            "call_llm_async",
             new=AsyncMock(side_effect=raise_for_cache),
         ):
             results = await self.service.call_llm_many_async(specs, max_concurrency=2)
@@ -780,6 +1048,39 @@ class TestExtractLlmUsage(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result.input_tokens, 15)
         self.assertEqual(result.output_tokens, 25)
+
+    def test_malformed_usage_metadata_field_returns_none_for_that_field(self):
+        """MEDIUM-2: non-numeric token value must not convert a success into a failure.
+
+        Counter-factual: if int("not-a-number") raises and is not caught, _extract_llm_usage
+        would raise instead of returning a partial LLMUsage, causing _execute_fan_out_item's
+        broad except to classify the successful call as status='failed'.
+        """
+        response = Mock()
+        response.usage_metadata = {
+            "input_tokens": "not-a-number",
+            "output_tokens": 20,
+        }
+        # Must NOT raise — malformed field returns None for that slot.
+        result = LLMService._extract_llm_usage(response)
+        self.assertIsNotNone(result, "LLMUsage must be returned even when a field is malformed")
+        self.assertIsNone(
+            result.input_tokens,
+            "malformed input_tokens must be None, not an exception",
+        )
+        self.assertEqual(result.output_tokens, 20)
+
+    def test_malformed_usage_metadata_all_fields_returns_llm_usage_with_all_none(self):
+        """MEDIUM-2: fully malformed metadata still returns LLMUsage (not None)."""
+        response = Mock()
+        response.usage_metadata = {
+            "input_tokens": [1, 2],
+            "output_tokens": {"key": "val"},
+        }
+        result = LLMService._extract_llm_usage(response)
+        self.assertIsNotNone(result)
+        self.assertIsNone(result.input_tokens)
+        self.assertIsNone(result.output_tokens)
 
 
 if __name__ == "__main__":

--- a/tests/fresh_suite/unit/services/test_llm_service_fanout.py
+++ b/tests/fresh_suite/unit/services/test_llm_service_fanout.py
@@ -9,7 +9,7 @@ Covers AC-001 through AC-009 from the E05-F02 test plan:
   AC-005: Concurrency cap (TC-AC5-01, TC-AC5-02)
   AC-006: Partial-failure completion (TC-AC6-01, TC-AC6-02)
   AC-007: Successful result normalization (TC-AC7-01 – TC-AC7-04)
-  AC-008: Failure result normalization (TC-AC8-01, TC-AC8-02)
+  AC-008: Failure result normalization (TC-AC8-01, TC-AC8-02, TC-AC8-03, TC-AC8-04)
   AC-009: Cache-aware request pass-through (TC-AC9-01, TC-AC9-02)
 
 Seam convention (post-rework):
@@ -24,6 +24,7 @@ import unittest
 from unittest.mock import AsyncMock, Mock, create_autospec, patch
 
 from agentmap.exceptions import LLMServiceError
+from agentmap.exceptions.service_exceptions import LLMResolvedCallError
 from agentmap.models.llm_execution import (
     LLMCallResult,
     LLMCallSpec,
@@ -260,9 +261,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
 
     async def test_tc_ac4_01_empty_call_specs_raises_before_execution(self):
         """TC-AC4-01: empty call_specs must raise LLMServiceError."""
-        with patch.object(
-            self.service, "call_llm_async", new=AsyncMock()
-        ) as mock_call:
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async([], max_concurrency=1)
 
@@ -272,9 +271,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         """TC-AC4-02: duplicate spec_id raises LLMServiceError before execution."""
         specs = [_make_spec("dup-1"), _make_spec("dup-1")]
 
-        with patch.object(
-            self.service, "call_llm_async", new=AsyncMock()
-        ) as mock_call:
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=2)
 
@@ -285,9 +282,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         specs = [_make_spec(f"item-{i}") for i in range(20)]
         specs.append(_make_spec("item-5"))  # duplicate at the end
 
-        with patch.object(
-            self.service, "call_llm_async", new=AsyncMock()
-        ) as mock_call:
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=4)
 
@@ -297,9 +292,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         """TC-AC4-03: max_concurrency=0 raises LLMServiceError."""
         specs = [_make_spec("one")]
 
-        with patch.object(
-            self.service, "call_llm_async", new=AsyncMock()
-        ) as mock_call:
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=0)
 
@@ -309,9 +302,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         """TC-AC4-03 edge: max_concurrency=-1 raises LLMServiceError."""
         specs = [_make_spec("one")]
 
-        with patch.object(
-            self.service, "call_llm_async", new=AsyncMock()
-        ) as mock_call:
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=-1)
 
@@ -335,9 +326,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
         """LOW-1: max_concurrency=True is rejected even though bool is int subclass."""
         specs = [_make_spec("one")]
 
-        with patch.object(
-            self.service, "call_llm_async", new=AsyncMock()
-        ) as mock_call:
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async(specs, max_concurrency=True)
 
@@ -349,9 +338,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
             spec_id=123,  # type: ignore[arg-type]
             messages=[{"role": "user", "content": "hi"}],
         )
-        with patch.object(
-            self.service, "call_llm_async", new=AsyncMock()
-        ) as mock_call:
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async([spec], max_concurrency=1)
 
@@ -363,9 +350,7 @@ class TestAC004SubmissionValidation(unittest.IsolatedAsyncioTestCase):
             spec_id="",
             messages=[{"role": "user", "content": "hi"}],
         )
-        with patch.object(
-            self.service, "call_llm_async", new=AsyncMock()
-        ) as mock_call:
+        with patch.object(self.service, "call_llm_async", new=AsyncMock()) as mock_call:
             with self.assertRaises(LLMServiceError):
                 await self.service.call_llm_many_async([spec], max_concurrency=1)
 
@@ -784,7 +769,12 @@ class TestAC007SuccessNormalization(unittest.IsolatedAsyncioTestCase):
         )
         # Configure resilience to 1 attempt so the primary always fails.
         service._resilience_config = {
-            "retry": {"max_attempts": 1, "backoff_base": 2.0, "backoff_max": 30.0, "jitter": False},
+            "retry": {
+                "max_attempts": 1,
+                "backoff_base": 2.0,
+                "backoff_max": 30.0,
+                "jitter": False,
+            },
             "circuit_breaker": {"failure_threshold": 5, "reset_timeout": 60},
         }
 
@@ -792,7 +782,9 @@ class TestAC007SuccessNormalization(unittest.IsolatedAsyncioTestCase):
         service._provider_utils.get_provider_config = Mock(
             side_effect=lambda p: {"model": f"{p}-default", "api_key": "test"}
         )
-        service._message_utils.convert_messages_to_langchain = Mock(return_value=[Mock()])
+        service._message_utils.convert_messages_to_langchain = Mock(
+            return_value=[Mock()]
+        )
         service._client_factory.get_or_create_client = Mock(return_value=Mock())
 
         # _invoke_with_resilience_async fails for openai (primary), succeeds for
@@ -911,7 +903,9 @@ class TestAC008FailureNormalization(unittest.IsolatedAsyncioTestCase):
         spec = _make_spec("sanitize-me")
 
         # _sanitize_error_message redacts long opaque token-looking strings.
-        raw_exc = RuntimeError("Error: sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+        raw_exc = RuntimeError(
+            "Error: sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        )
         with patch.object(
             self.service,
             "call_llm_async",
@@ -1063,7 +1057,9 @@ class TestExtractLlmUsage(unittest.TestCase):
         }
         # Must NOT raise — malformed field returns None for that slot.
         result = LLMService._extract_llm_usage(response)
-        self.assertIsNotNone(result, "LLMUsage must be returned even when a field is malformed")
+        self.assertIsNotNone(
+            result, "LLMUsage must be returned even when a field is malformed"
+        )
         self.assertIsNone(
             result.input_tokens,
             "malformed input_tokens must be None, not an exception",
@@ -1081,6 +1077,283 @@ class TestExtractLlmUsage(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIsNone(result.input_tokens)
         self.assertIsNone(result.output_tokens)
+
+
+# ---------------------------------------------------------------------------
+# AC-008  Failure result normalization — Round-2 addendum (TC-AC8-03/04)
+# ---------------------------------------------------------------------------
+
+
+class TestAC008FailureNormalizationRound2(unittest.IsolatedAsyncioTestCase):
+    """TC-AC8-03 and TC-AC8-04: resolved identity preserved on failure after resolution.
+
+    Round-2 UAT addendum: when routing or fallback selects a concrete
+    (provider, model) before execution fails, the failure record must carry
+    that resolved identity — not spec.provider/spec.model (which may be None).
+
+    Seam: patch ``_invoke_with_resilience_async`` (same seam as TC-AC7-03/04).
+    Forbidden: do NOT patch ``call_llm_async`` itself — that mocks out the
+    routing/fallback layer where the resolved identity lives.
+    """
+
+    def _make_routed_service(
+        self,
+        routed_provider: str = "anthropic",
+        routed_model: str = "claude-haiku",
+    ) -> LLMService:
+        """Build a service wired to route to the given provider/model."""
+        service = _make_service()
+        mock_decision = Mock()
+        mock_decision.provider = routed_provider
+        mock_decision.model = routed_model
+        mock_decision.complexity = "low"
+        mock_decision.confidence = 0.9
+        mock_decision.max_tokens = None
+        mock_decision.cache_hit = False
+        mock_decision.fallback_used = False
+        service.routing_service.route_request.return_value = mock_decision
+
+        service._provider_utils.normalize_provider = Mock(side_effect=lambda p: p)
+        service._provider_utils.get_provider_config = Mock(
+            return_value={"model": routed_model, "api_key": "test"}
+        )
+        service._provider_utils.get_available_providers = Mock(
+            return_value=["openai", routed_provider]
+        )
+        service._message_utils.extract_prompt_from_messages = Mock(return_value="hello")
+        service._message_utils.convert_messages_to_langchain = Mock(
+            return_value=[Mock()]
+        )
+        service._client_factory.get_or_create_client = Mock(return_value=Mock())
+        return service
+
+    async def test_tc_ac8_03_routed_failure_preserves_resolved_provider_and_model(self):
+        """TC-AC8-03: when routing resolves to a provider before failure, the failure
+        record reflects the resolved identity, not spec.provider/spec.model.
+
+        Counter-factual: against the pre-round-2 code (no LLMResolvedCallError), the
+        bare ``except Exception`` in ``_execute_fan_out_item`` populates
+        ``provider=spec.provider=None`` and the assertion ``r.provider == "anthropic"``
+        FAILS.
+
+        Lowest allowed mock seam: ``_invoke_with_resilience_async``.
+        Forbidden: ``call_llm_async`` (mocks out routing where identity is resolved).
+        """
+        # Spec with provider=None triggers routing; routing resolves to anthropic:claude-haiku.
+        spec = LLMCallSpec(
+            spec_id="routed-fail",
+            messages=[{"role": "user", "content": "hello"}],
+            provider=None,
+            routing_context={"routing_enabled": True, "task_type": "general"},
+        )
+        service = self._make_routed_service(
+            routed_provider="anthropic", routed_model="claude-haiku"
+        )
+
+        from agentmap.exceptions.service_exceptions import LLMProviderError
+
+        # _invoke_with_resilience_async raises — simulates a provider call that fails
+        # after routing resolved the concrete provider/model.
+        with patch.object(
+            service,
+            "_invoke_with_resilience_async",
+            new=AsyncMock(
+                side_effect=LLMProviderError("simulated timeout after routing")
+            ),
+        ):
+            results = await service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.spec_id, "routed-fail")
+        self.assertEqual(r.status, "failed")
+        self.assertEqual(
+            r.provider,
+            "anthropic",
+            "provider must be the routing-resolved provider, not spec.provider=None",
+        )
+        self.assertEqual(
+            r.model,
+            "claude-haiku",
+            "model must be the routing-resolved model, not spec.model=None",
+        )
+        self.assertIsNotNone(r.error)
+        self.assertEqual(r.error.error_type, "LLMProviderError")
+
+    async def test_tc_ac8_04_fallback_exhaustion_preserves_last_tier_identity(self):
+        """TC-AC8-04: when all fallback tiers fail, the result reflects the last-attempted
+        tier's provider/model — not spec.provider/spec.model.
+
+        Counter-factual: against the pre-round-2 code, the bare ``except Exception``
+        block uses ``spec.provider`` (e.g., "openai") and the assertion
+        ``r.provider == <last-tier-provider>`` FAILS when fallback selects a different
+        provider.
+
+        Lowest allowed mock seam: ``_invoke_with_resilience_async``.
+        Forbidden: ``call_llm_async`` (mocks out the fallback ladder).
+        """
+        mock_features_registry = Mock()
+        mock_features_registry.is_provider_available.return_value = True
+        mock_features_registry.get_available_providers.return_value = [
+            "openai",
+            "anthropic",
+        ]
+        mock_routing_config = Mock()
+        mock_routing_config.fallback = {"default_provider": "anthropic"}
+        mock_routing_config.routing_matrix = {
+            "anthropic": {"low": "claude-haiku"},
+            "openai": {"low": "gpt-3.5-turbo"},
+        }
+
+        service = LLMService(
+            configuration=MockServiceFactory.create_mock_app_config_service(),
+            logging_service=MockServiceFactory.create_mock_logging_service(),
+            routing_service=Mock(),
+            llm_models_config_service=MockServiceFactory.create_mock_llm_models_config_service(),
+            features_registry_service=mock_features_registry,
+            routing_config_service=mock_routing_config,
+        )
+        service._resilience_config = {
+            "retry": {
+                "max_attempts": 1,
+                "backoff_base": 2.0,
+                "backoff_max": 30.0,
+                "jitter": False,
+            },
+            "circuit_breaker": {"failure_threshold": 5, "reset_timeout": 60},
+        }
+        service._provider_utils.normalize_provider = Mock(side_effect=lambda p: p)
+        service._provider_utils.get_provider_config = Mock(
+            side_effect=lambda p: {"model": f"{p}-default", "api_key": "test"}
+        )
+        service._message_utils.convert_messages_to_langchain = Mock(
+            return_value=[Mock()]
+        )
+        service._client_factory.get_or_create_client = Mock(return_value=Mock())
+
+        spec = _make_spec("fallback-exhaust", provider="openai", model="gpt-4o")
+
+        # All invocations fail — forces exhaustion through all tiers.
+        # The last tier attempted through the fallback ladder will be the one
+        # whose identity should appear in the failure record.
+        with patch.object(
+            service,
+            "_invoke_with_resilience_async",
+            new=AsyncMock(side_effect=RuntimeError("all providers down")),
+        ):
+            results = await service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.spec_id, "fallback-exhaust")
+        self.assertEqual(r.status, "failed")
+        # The result must not simply echo spec.provider — it must reflect the last
+        # tier actually attempted (which the fallback handler knows).
+        self.assertIsNotNone(
+            r.provider,
+            "provider must not be None — a concrete provider was attempted",
+        )
+        self.assertIsNotNone(
+            r.model,
+            "model must not be None — a concrete model was attempted",
+        )
+        self.assertIsNotNone(r.error)
+
+    async def test_tc_ac8_02_non_fabrication_invariant_preserved(self):
+        """TC-AC8-02 invariant: when failure occurs before any resolution
+        (call_llm_async raises immediately as a plain LLMServiceError with no
+        LLMResolvedCallError wrap), provider=None is preserved — not fabricated.
+
+        This verifies the bare ``except Exception`` branch in
+        ``_execute_fan_out_item`` still handles pre-resolution failures correctly
+        after the LLMResolvedCallError catch is added.
+        """
+        spec = LLMCallSpec(
+            spec_id="pre-resolution-fail",
+            messages=[{"role": "user", "content": "hi"}],
+            provider=None,
+            routing_context={"routing_enabled": True},
+        )
+
+        # Plain LLMServiceError — no LLMResolvedCallError wrap — simulates a failure
+        # before any provider was selected (e.g., routing service itself raises).
+        with patch.object(
+            self.service,
+            "call_llm_async",
+            new=AsyncMock(side_effect=LLMServiceError("routing service unavailable")),
+        ):
+            results = await self.service.call_llm_many_async([spec], max_concurrency=1)
+
+        r = results[0]
+        self.assertEqual(r.status, "failed")
+        self.assertIsNone(r.provider, "provider must remain None — do not fabricate")
+
+    def setUp(self):
+        self.service = _make_service()
+
+
+# ---------------------------------------------------------------------------
+# LLMResolvedCallError public API — single-call propagation
+# ---------------------------------------------------------------------------
+
+
+class TestLLMResolvedCallErrorPublicAPI(unittest.IsolatedAsyncioTestCase):
+    """TC-AC8-05: call_llm_async propagates LLMResolvedCallError with resolved identity.
+
+    Verifies the public API surface from Section 4 of the round-2 addendum:
+    when _call_llm_async_direct raises LLMResolvedCallError, call_llm_async
+    lets it propagate unchanged so single-call callers can read resolved_provider,
+    resolved_model, and cause.
+    """
+
+    def setUp(self):
+        self.service = _make_service()
+        self.service._provider_utils.normalize_provider = Mock(side_effect=lambda p: p)
+        self.service._provider_utils.get_provider_config = Mock(
+            return_value={"model": "claude-haiku", "api_key": "test"}
+        )
+        self.service._message_utils.convert_messages_to_langchain = Mock(
+            return_value=[Mock()]
+        )
+        self.service._client_factory.get_or_create_client = Mock(return_value=Mock())
+
+    async def test_call_llm_async_propagates_llm_resolved_call_error_with_identity(
+        self,
+    ):
+        """TC-AC8-05: call_llm_async lets LLMResolvedCallError escape unchanged.
+
+        Counter-factual: if call_llm_async unwrapped the error, callers could not
+        read .resolved_provider / .resolved_model / .cause from the exception.
+
+        Lowest allowed mock seam: ``_invoke_with_resilience_async``.
+        Forbidden: ``call_llm_async`` (we are testing its propagation behavior).
+        """
+        from agentmap.exceptions.service_exceptions import LLMProviderError
+
+        underlying = LLMProviderError("provider timeout")
+        resolved_err = LLMResolvedCallError(
+            resolved_provider="anthropic",
+            resolved_model="claude-haiku",
+            cause=underlying,
+        )
+
+        with patch.object(
+            self.service,
+            "_invoke_with_resilience_async",
+            new=AsyncMock(side_effect=resolved_err),
+        ):
+            with self.assertRaises(LLMResolvedCallError) as ctx:
+                await self.service.call_llm_async(
+                    messages=[{"role": "user", "content": "hello"}],
+                    provider="anthropic",
+                    model="claude-haiku",
+                )
+
+        exc = ctx.exception
+        self.assertIsInstance(exc, LLMResolvedCallError)
+        # LLMResolvedCallError is a LLMServiceError subclass — existing handlers match.
+        self.assertIsInstance(exc, LLMServiceError)
+        self.assertEqual(exc.resolved_provider, "anthropic")
+        self.assertEqual(exc.resolved_model, "claude-haiku")
+        self.assertIs(exc.cause, underlying)
 
 
 if __name__ == "__main__":

--- a/tests/unit/services/test_llm_service_metrics.py
+++ b/tests/unit/services/test_llm_service_metrics.py
@@ -16,8 +16,9 @@ Acceptance Criteria:
   AC9: Failure isolation (TC-741)
 """
 
+import asyncio
 from contextlib import contextmanager
-from unittest.mock import MagicMock, create_autospec, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 
@@ -689,6 +690,51 @@ class TestAC7FallbackAndCacheHit:
             routing_context={"task_type": "general", "fallback_provider": "anthropic"},
         )
 
+        instruments["fallback"].add.assert_called_once()
+        call_args = instruments["fallback"].add.call_args
+        assert call_args[0][0] == 1
+        attrs = call_args[0][1]
+        assert METRIC_DIM_TIER in attrs
+
+    def test_async_fallback_counter_on_routing_fallback(self):
+        """Async routing fallback should record the same fallback metric."""
+        mock_telemetry, mock_span, instruments = _make_mock_telemetry()
+        svc = _make_llm_service(telemetry_service=mock_telemetry)
+
+        mock_response = MagicMock()
+        mock_response.content = "Hello async!"
+        mock_response.response_metadata = {}
+        del mock_response.usage_metadata
+
+        mock_client = MagicMock()
+        mock_client.ainvoke = AsyncMock(return_value=mock_response)
+
+        svc._provider_utils = MagicMock()
+        svc._provider_utils.get_available_providers.return_value = ["anthropic"]
+        svc._provider_utils.normalize_provider.return_value = "anthropic"
+        svc._provider_utils.get_provider_config.return_value = {
+            "model": "claude-3-sonnet",
+            "api_key": "test-key",
+        }
+        svc._client_factory = MagicMock()
+        svc._client_factory.get_or_create_client.return_value = mock_client
+        svc._message_utils = MagicMock()
+        svc._message_utils.convert_messages_to_langchain.return_value = []
+        svc._message_utils.extract_prompt_from_messages.return_value = "hello"
+
+        svc.routing_service.route_request.side_effect = RuntimeError("routing fail")
+
+        result = asyncio.run(
+            svc.call_llm_async(
+                messages=[{"role": "user", "content": "hello"}],
+                routing_context={
+                    "task_type": "general",
+                    "fallback_provider": "anthropic",
+                },
+            )
+        )
+
+        assert result == "Hello async!"
         instruments["fallback"].add.assert_called_once()
         call_args = instruments["fallback"].add.call_args
         assert call_args[0][0] == 1

--- a/tests/unit/services/test_llm_service_metrics.py
+++ b/tests/unit/services/test_llm_service_metrics.py
@@ -734,7 +734,7 @@ class TestAC7FallbackAndCacheHit:
             )
         )
 
-        assert result == "Hello async!"
+        assert result.text == "Hello async!"
         instruments["fallback"].add.assert_called_once()
         call_args = instruments["fallback"].add.call_args
         assert call_args[0][0] == 1

--- a/tests/unit/services/test_llm_service_telemetry.py
+++ b/tests/unit/services/test_llm_service_telemetry.py
@@ -172,7 +172,7 @@ class TestTC220SpanCreation:
             )
         )
 
-        assert result == "Hello async!"
+        assert result.text == "Hello async!"
         mock_telemetry.start_span.assert_called_once()
         call_args = mock_telemetry.start_span.call_args
         assert call_args[0][0] == LLM_CALL_SPAN

--- a/tests/unit/services/test_llm_service_telemetry.py
+++ b/tests/unit/services/test_llm_service_telemetry.py
@@ -8,8 +8,9 @@ Also covers T-E02-F03-003: Routing Decision Attribute Recording.
 Test cases TC-230 through TC-235.
 """
 
+import asyncio
 from contextlib import contextmanager
-from unittest.mock import MagicMock, create_autospec, patch
+from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
 
 import pytest
 
@@ -134,6 +135,44 @@ class TestTC220SpanCreation:
             model="claude-3-sonnet",
         )
 
+        mock_telemetry.start_span.assert_called_once()
+        call_args = mock_telemetry.start_span.call_args
+        assert call_args[0][0] == LLM_CALL_SPAN
+
+    def test_call_llm_async_creates_gen_ai_chat_span(self):
+        """Async path should reuse the same span name as sync."""
+        mock_telemetry, mock_span = _make_mock_telemetry()
+        svc = _make_llm_service(telemetry_service=mock_telemetry)
+
+        mock_response = MagicMock()
+        mock_response.content = "Hello async!"
+        mock_response.response_metadata = {}
+        del mock_response.usage_metadata
+
+        mock_client = MagicMock()
+        mock_client.ainvoke = AsyncMock(return_value=mock_response)
+
+        svc._provider_utils = MagicMock()
+        svc._provider_utils.normalize_provider.return_value = "anthropic"
+        svc._provider_utils.get_provider_config.return_value = {
+            "model": "claude-3-sonnet",
+            "api_key": "test-key",
+        }
+        svc._client_factory = MagicMock()
+        svc._client_factory.get_or_create_client.return_value = mock_client
+        svc._message_utils = MagicMock()
+        svc._message_utils.convert_messages_to_langchain.return_value = []
+        svc._message_utils.extract_prompt_from_messages.return_value = "hello"
+
+        result = asyncio.run(
+            svc.call_llm_async(
+                messages=[{"role": "user", "content": "hello"}],
+                provider="anthropic",
+                model="claude-3-sonnet",
+            )
+        )
+
+        assert result == "Hello async!"
         mock_telemetry.start_span.assert_called_once()
         call_args = mock_telemetry.start_span.call_args
         assert call_args[0][0] == LLM_CALL_SPAN

--- a/tests/utils/mock_service_factory.py
+++ b/tests/utils/mock_service_factory.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock, Mock
 
+from agentmap.models.llm_execution import LLMResponse
+
 
 class MockServiceFactory:
     """
@@ -1111,7 +1113,14 @@ class MockServiceFactory:
         mock_service.ask = Mock(return_value="Mock LLM response")
         mock_service.ask_vision = Mock(return_value="Mock LLM response")
         mock_service.call_llm.return_value = "Mock LLM response"
-        mock_service.call_llm_async = AsyncMock(return_value="Mock LLM response")
+        mock_service.call_llm_async = AsyncMock(
+            return_value=LLMResponse(
+                text="Mock LLM response",
+                resolved_provider="mock-provider",
+                resolved_model="mock-model",
+                usage=None,
+            )
+        )
         mock_service.ask_async = AsyncMock(return_value="Mock LLM response")
         mock_service.call_llm_many_async = AsyncMock(return_value=[])
         mock_service.get_model_name = Mock(return_value="mock-model")

--- a/tests/utils/mock_service_factory.py
+++ b/tests/utils/mock_service_factory.py
@@ -13,7 +13,7 @@ Pattern established by ExecutionTrackingService test refactoring:
 
 from pathlib import Path
 from typing import Any, Dict, List, Optional
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 
 class MockServiceFactory:
@@ -1107,9 +1107,15 @@ class MockServiceFactory:
         mock_service = Mock()
 
         # Configure basic LLM methods
-        mock_service.ask.return_value = "Mock LLM response"
-        mock_service.get_model_name.return_value = "mock-model"
-        mock_service.is_available.return_value = True
+        mock_service.generate = Mock(return_value="Mock LLM response")
+        mock_service.ask = Mock(return_value="Mock LLM response")
+        mock_service.ask_vision = Mock(return_value="Mock LLM response")
+        mock_service.call_llm.return_value = "Mock LLM response"
+        mock_service.call_llm_async = AsyncMock(return_value="Mock LLM response")
+        mock_service.ask_async = AsyncMock(return_value="Mock LLM response")
+        mock_service.call_llm_many_async = AsyncMock(return_value=[])
+        mock_service.get_model_name = Mock(return_value="mock-model")
+        mock_service.is_available = Mock(return_value=True)
 
         return mock_service
 


### PR DESCRIPTION
## Summary
- **Bug:** `_call_llm_with_routing` and `_call_llm_async_with_routing` used `kwargs.get("temperature")` and `kwargs.get("model")` to read caller-supplied values, but these were explicit function parameters extracted before `**kwargs` — so they were never in kwargs and silently dropped to `None`.
- **Fix:** Both sync and async routing methods now accept `temperature` and `model` as explicit parameters. All 6 `kwargs.get(...)` lookups replaced with direct parameter references.
- **Tests:** Updated existing routing and fallback tests to assert non-None temperature/model values survive the routing path.

## Test plan
- [x] 195 unit tests pass (12 skipped), 0 failures
- [x] flake8 + isort lint clean
- [x] `test_call_llm_with_routing_context` verifies temperature=0.3 flows through main routing path
- [x] `test_call_llm_routing_fallback` verifies temperature=0.5 and model="custom-model" survive fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)