### PR TITLE
feat(llm): async ask_vision_async + finish_reason + failover-safe prompt caching

### DIFF
--- a/docs-docusaurus/docs/configuration/llm-config.md
+++ b/docs-docusaurus/docs/configuration/llm-config.md
@@ -144,8 +144,8 @@ routing:
 - Omit `provider_capabilities` entirely if you do not need prompt caching
 - `prompt_caching: true` means the provider may be selected for cache-aware realtime text requests
 - `prompt_caching: false` means direct cache-mode requests fail before provider invocation, and routed cache-mode requests exclude that provider
-- Current support is limited to realtime text calls: `call_llm()`, `call_llm_async()`, `ask()`, `ask_async()`
-- `ask_vision()` is explicitly unsupported for prompt caching
+- Supported on realtime text calls — `call_llm()`, `call_llm_async()`, `ask()`, `ask_async()` — and on vision via `ask_vision_async(cache_prompt=True)`
+- The synchronous `ask_vision()` does not request prompt caching; on failover the cache marker is stripped before non-primary tiers, so a non-caching fallback provider is never rejected for it
 
 **Note:** `cache_system_prompt=True` (the provider-agnostic caching parameter) uses the `prompt_caching` capability check for most providers, with one exception: OpenAI is always a no-op (automatic server-side caching) and is never rejected regardless of the `prompt_caching` setting. For all other providers, `prompt_caching: false` rejects both `cache_system_prompt=True` and manual `cache_control` passthrough before provider invocation. There is one capability flag for both styles — you do not need separate configuration for each, except that OpenAI requires no configuration to use `cache_system_prompt=True`.
 

--- a/docs-docusaurus/docs/reference/services/llm-service.md
+++ b/docs-docusaurus/docs/reference/services/llm-service.md
@@ -181,6 +181,30 @@ Routing filters candidates to providers whose `routing.provider_capabilities.<pr
 
 ---
 
+### Pattern 4: Async vision (`ask_vision_async()`)
+
+`ask_vision_async()` sends an image plus a text prompt through the full async stack — intelligent routing, tiered fallback, and resilience — and returns a rich `LLMResponse` (text, `resolved_provider`, `resolved_model`, `usage`, and `finish_reason`). It builds the multimodal message for you, so callers pass raw bytes (or a path) and a prompt, not hand-built content blocks. `requires_vision=True` is injected into the routing context automatically.
+
+```python
+response = await llm_service.ask_vision_async(
+    prompt="Transcribe the page as JSON.",
+    image=image_bytes,                       # bytes (preferred) or a file path
+    image_type="image/png",
+    routing_context={"activity": "ocr_extraction"},
+    cache_prompt=True,                        # opt-in prompt caching, see below
+    max_tokens=4096,
+)
+text = response.text
+provider = response.resolved_provider         # the provider that actually answered
+truncated = response.finish_reason == "max_tokens"
+```
+
+- **`cache_prompt`** (default `False`): when `True`, AgentMap attaches `cache_control` to the prompt text block and sets `routing_context["requires_prompt_caching"] = True`, so routing keeps the **primary** pick on a cache-capable provider (see [Pattern 3b](#pattern-3b-routed-prompt-caching-call)). Caching is a happy-path optimization — it does not weaken failover (see [Tiered Fallback](#tiered-fallback)).
+- **`finish_reason`** on the returned `LLMResponse` exposes the provider stop reason (e.g. `"max_tokens"` for a truncated response), extracted from the provider response metadata.
+- The synchronous `ask_vision()` remains available and returns the response text as a `str`; prefer `ask_vision_async()` when you need routing/fallback metadata or token usage.
+
+---
+
 ## Resilience & Retries
 
 Every LLM call is automatically protected by retry with exponential backoff and a circuit breaker. No additional configuration is required to get these protections — they are on by default.
@@ -228,6 +252,8 @@ When a call fails after all retries are exhausted, a tiered fallback strategy ki
 | 4 | All fallbacks exhausted — raises `LLMServiceError` with full context | — |
 
 Dependency errors (missing packages) and configuration errors (bad API key) skip fallback entirely. Only transient provider errors trigger the fallback chain.
+
+The `requires_prompt_caching` filter (Pattern 3b) constrains only the **primary** routing pick — it does **not** restrict the fallback ladder, so failover still reaches non-caching providers when the cache-capable primary is down. Because Anthropic `cache_control` is provider-specific and can be rejected at another provider's API boundary, the fallback handler strips `cache_control` from the messages before invoking each fallback tier. Prompt-cache savings apply on the primary; recovery calls run un-cached but compatible.
 
 ---
 
@@ -409,9 +435,10 @@ For advanced manual `cache_control` construction see [Pattern 1b: Direct prompt-
 
 ## Prompt-Caching Limits
 
-- Supported execution paths in this feature slice: `call_llm()`, `call_llm_async()`, `ask()`, `ask_async()`
-- Unsupported execution path in this feature slice: `ask_vision()`
+- Supported execution paths: `call_llm()`, `call_llm_async()`, `ask()`, `ask_async()`, and `ask_vision_async(cache_prompt=True)`
+- The synchronous `ask_vision()` does not request prompt caching; use `ask_vision_async(cache_prompt=True)` for cache-aware vision
 - Prompt caching is provider-gated through `routing.provider_capabilities`
+- On failover, `cache_control` is stripped before non-primary tiers (see [Tiered Fallback](#tiered-fallback)), so caching never blocks recovery
 - Existing plain-text and non-cache structured requests keep their prior behavior
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentmap"
-version = "0.9.209"
+version = "0.9.210"
 description = "AgentMap: Build and deploy LangGraph agentic workflows from CSV files for fun and profit!"
 authors = [{ name = "John Welborn", email = "jwwelbor@gmail.com" }]
 requires-python = ">=3.11,<4.0"

--- a/src/agentmap/_version.py
+++ b/src/agentmap/_version.py
@@ -1,2 +1,2 @@
 # change here and in pyproject.toml
-__version__ = "0.9.209"
+__version__ = "0.9.210"

--- a/src/agentmap/models/llm_execution.py
+++ b/src/agentmap/models/llm_execution.py
@@ -35,12 +35,18 @@ class LLMResponse:
 
     ``usage`` is ``None`` only when the underlying provider did not return
     ``usage_metadata`` on the response.
+
+    ``finish_reason`` is the provider's normalized stop reason when available
+    (e.g. Anthropic ``stop_reason`` / OpenAI/Google ``finish_reason``), read
+    from the response metadata. It is ``None`` when the provider did not report
+    one. Callers use it to detect truncation (``"max_tokens"`` / ``"length"``).
     """
 
     text: str
     resolved_provider: str
     resolved_model: str
     usage: Optional["LLMUsage"] = None
+    finish_reason: Optional[str] = None
 
 
 @dataclass

--- a/src/agentmap/services/llm_fallback_handler.py
+++ b/src/agentmap/services/llm_fallback_handler.py
@@ -15,6 +15,7 @@ from agentmap.exceptions.service_exceptions import LLMResolvedCallError
 from agentmap.models.llm_execution import LLMMessage, LLMResponse
 from agentmap.services.config.llm_routing_config_service import LLMRoutingConfigService
 from agentmap.services.features_registry_service import FeaturesRegistryService
+from agentmap.services.llm_message_service import LLMMessageService
 from agentmap.services.logging_service import LoggingService
 
 
@@ -216,7 +217,10 @@ class LLMFallbackHandler:
         )
 
         attempted_fallbacks = []
-        langchain_msgs = convert_messages_fn(messages)
+        # Strip Anthropic-only cache_control before failover (see async variant).
+        langchain_msgs = convert_messages_fn(
+            LLMMessageService.strip_cache_control(messages)
+        )
 
         # Use shared tier plan — keeps sync/async ladders in sync (DRY).
         for fallback_provider, fallback_model in self._build_tier_plan(
@@ -279,7 +283,12 @@ class LLMFallbackHandler:
         )
 
         attempted_fallbacks = []
-        langchain_msgs = convert_messages_fn(messages)
+        # Strip Anthropic-only cache_control before failover — non-Anthropic
+        # fallback providers can reject it at their API boundary, and prompt-cache
+        # savings are moot on a recovery call.
+        langchain_msgs = convert_messages_fn(
+            LLMMessageService.strip_cache_control(messages)
+        )
         # Last tier actually invoked.
         # Updated immediately before _invoke_client_async so it only reflects providers
         # where an actual network call was attempted (MEDIUM-2 fix).

--- a/src/agentmap/services/llm_message_service.py
+++ b/src/agentmap/services/llm_message_service.py
@@ -61,6 +61,44 @@ class LLMMessageService:
         return False
 
     @staticmethod
+    def strip_cache_control(
+        messages: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Return a copy of *messages* with all ``cache_control`` blocks removed.
+
+        ``cache_control`` is an Anthropic-specific content-block extension. When a
+        request fails over to a non-Anthropic provider, reusing the original
+        Anthropic-tagged messages can be rejected at that provider's API boundary.
+        Fallback tiers are recovery calls where prompt-cache savings are moot, so
+        the tier ladder strips the marker to guarantee cross-provider
+        compatibility. Messages without any ``cache_control`` are returned as-is
+        (no copy) — this is a no-op for the common case.
+
+        Args:
+            messages: List of message dictionaries (content may be a str or a
+                list of structured content blocks).
+
+        Returns:
+            A new message list with ``cache_control`` stripped from every content
+            block, or the original list when nothing needed stripping.
+        """
+        if not LLMMessageService.has_prompt_caching(messages):
+            return messages
+
+        sanitized: List[Dict[str, Any]] = []
+        for msg in messages:
+            if not isinstance(msg, dict) or not isinstance(msg.get("content"), list):
+                sanitized.append(msg)
+                continue
+            new_content = []
+            for block in msg["content"]:
+                if isinstance(block, dict) and "cache_control" in block:
+                    block = {k: v for k, v in block.items() if k != "cache_control"}
+                new_content.append(block)
+            sanitized.append({**msg, "content": new_content})
+        return sanitized
+
+    @staticmethod
     def extract_prompt_from_messages(messages: List[Dict[str, Any]]) -> str:
         """
         Extract the main prompt content from messages for complexity analysis.

--- a/src/agentmap/services/llm_service.py
+++ b/src/agentmap/services/llm_service.py
@@ -1309,6 +1309,7 @@ class LLMService:
                     resolved_provider=provider,
                     resolved_model=model,
                     usage=self._extract_llm_usage(response),
+                    finish_reason=self._extract_finish_reason(response),
                 )
             except Exception as e:
                 typed_error = classify_llm_error(e, provider)
@@ -1593,6 +1594,99 @@ class LLMService:
             provider = "anthropic"
 
         return self.call_llm(
+            messages=messages,
+            provider=provider,
+            model=model,
+            temperature=temperature,
+            routing_context=routing_context,
+            **kwargs,
+        )
+
+    async def ask_vision_async(
+        self,
+        prompt: str,
+        image: Union[str, bytes],
+        image_type: str = "image/png",
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        routing_context: Optional[Dict[str, Any]] = None,
+        cache_prompt: bool = False,
+        **kwargs,
+    ) -> LLMResponse:
+        """Async vision call returning a rich ``LLMResponse``.
+
+        Async counterpart of :meth:`ask_vision`. Constructs the multimodal
+        messages list and routes through :meth:`call_llm_async`, so it inherits
+        intelligent routing, tiered provider fallback, resilience (retry +
+        circuit breaker), and prompt caching — and returns the full
+        ``LLMResponse`` (``.text``, ``.resolved_provider``, ``.resolved_model``,
+        ``.usage``, ``.finish_reason``) rather than a bare string. Callers that
+        need per-call token usage or truncation detection should use this method
+        instead of the string-returning :meth:`ask_vision`.
+
+        Prompt caching: vision messages are a single user turn (image + text),
+        so the agnostic ``cache_system_prompt`` (which only marks *system*
+        messages) does not apply. Instead, ``cache_prompt=True`` attaches an
+        Anthropic ``cache_control`` block to the prompt text block (manual
+        passthrough) and sets ``routing_context["requires_prompt_caching"]`` so
+        routing selects a cache-capable provider (and excludes providers whose
+        ``routing.provider_capabilities.<p>.prompt_caching`` is false). For long,
+        static extraction/OCR prompts this caches the prompt's input tokens
+        across calls — a substantial cost saving. The capability gate is enforced
+        downstream against the *resolved* provider, so no pre-validation here.
+
+        Args:
+            prompt: Text prompt describing what to analyze.
+            image: Image as a file path (str) or raw bytes. Prefer ``bytes`` in
+                distributed/containerized environments.
+            image_type: MIME type when *image* is bytes (default ``image/png``).
+            provider: Optional provider name (defaults to ``'anthropic'`` only
+                when routing is not active).
+            model: Optional model override (ignored when routing_context is set).
+            temperature: Optional temperature override.
+            routing_context: Optional routing context for intelligent routing.
+                ``requires_vision=True`` is injected automatically; when
+                ``cache_prompt`` is set, ``requires_prompt_caching=True`` is too.
+            cache_prompt: When True, mark the prompt text block with
+                ``cache_control`` and request cache-aware routing.
+            **kwargs: Additional provider-specific parameters (e.g. ``max_tokens``).
+
+        Returns:
+            ``LLMResponse`` from the provider that actually handled the request.
+        """
+        image_bytes, mime = self._resolve_image(image, image_type)
+        b64 = base64.b64encode(image_bytes).decode("ascii")
+
+        text_block: Dict[str, Any] = {"type": "text", "text": prompt}
+        if cache_prompt:
+            text_block["cache_control"] = {"type": "ephemeral"}
+
+        messages: List[Dict[str, Any]] = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{mime};base64,{b64}"},
+                    },
+                    text_block,
+                ],
+            }
+        ]
+
+        # Inject vision/caching routing signals on a copy (never mutate caller's).
+        if routing_context is not None or cache_prompt:
+            routing_context = dict(routing_context or {})
+            routing_context["requires_vision"] = True
+            if cache_prompt:
+                routing_context["requires_prompt_caching"] = True
+
+        # Default provider only when routing is not active (mirrors ask_vision).
+        if provider is None and routing_context is None:
+            provider = "anthropic"
+
+        return await self.call_llm_async(
             messages=messages,
             provider=provider,
             model=model,
@@ -2399,6 +2493,23 @@ class LLMService:
             cache_creation_input_tokens=_get("cache_creation_input_tokens"),
             cache_read_input_tokens=cache_read_input_tokens,
         )
+
+    @staticmethod
+    def _extract_finish_reason(response: Any) -> Optional[str]:
+        """Extract the provider's normalized stop/finish reason, if any.
+
+        Reads ``response.response_metadata`` and returns the first of
+        ``stop_reason`` (Anthropic) or ``finish_reason`` (OpenAI / Google)
+        that is present. Returns ``None`` when metadata is absent or carries
+        no recognized key. Used by callers for truncation detection.
+        """
+        resp_meta = getattr(response, "response_metadata", None)
+        if not isinstance(resp_meta, dict):
+            return None
+        value = resp_meta.get("stop_reason")
+        if value is None:
+            value = resp_meta.get("finish_reason")
+        return str(value) if value is not None else None
 
     def get_available_providers(self) -> List[str]:
         """

--- a/src/agentmap/services/protocols/service_protocols.py
+++ b/src/agentmap/services/protocols/service_protocols.py
@@ -220,6 +220,43 @@ class LLMServiceProtocol(Protocol):
         """
         ...
 
+    async def ask_vision_async(
+        self,
+        prompt: str,
+        image: Union[str, bytes],
+        image_type: str = "image/png",
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        temperature: Optional[float] = None,
+        routing_context: Optional[Dict[str, Any]] = None,
+        cache_prompt: bool = False,
+        **kwargs,
+    ) -> LLMResponse:
+        """
+        Ask the LLM about an image asynchronously, returning a rich response.
+
+        Async counterpart of ``ask_vision`` that routes through
+        ``call_llm_async`` (routing, fallback, resilience, prompt caching) and
+        returns the full ``LLMResponse`` (text, resolved provider/model, usage,
+        finish_reason) instead of a bare string.
+
+        Args:
+            prompt: The prompt text describing what to analyze
+            image: Image as file path (str) or raw bytes
+            image_type: MIME type when image is bytes (default: image/png)
+            provider: Optional provider name
+            model: Optional model override
+            temperature: Optional temperature override
+            routing_context: Optional routing context for intelligent routing
+            cache_prompt: When True, attach cache_control to the prompt text
+                block and request cache-aware routing (prompt-token caching)
+            **kwargs: Additional provider-specific parameters (e.g. max_tokens)
+
+        Returns:
+            LLMResponse with text, resolved provider/model, usage, finish_reason
+        """
+        ...
+
     async def call_llm_many_async(
         self,
         requests: List[LLMRequest],

--- a/tests/fresh_suite/unit/services/test_llm_message_service.py
+++ b/tests/fresh_suite/unit/services/test_llm_message_service.py
@@ -402,5 +402,54 @@ class TestLLMMessageServiceRenameVerification(unittest.TestCase):
         self.assertTrue(callable(svc.inject_cache_metadata))
 
 
+class TestStripCacheControl(unittest.TestCase):
+    """strip_cache_control removes Anthropic-only cache_control for failover."""
+
+    def test_strips_cache_control_from_structured_block(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "data:..."}},
+                    {
+                        "type": "text",
+                        "text": "extract",
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                ],
+            }
+        ]
+        out = LLMMessageService.strip_cache_control(messages)
+        self.assertFalse(LLMMessageService.has_prompt_caching(out))
+        # Original is not mutated.
+        self.assertTrue(LLMMessageService.has_prompt_caching(messages))
+        # Non-cache fields preserved.
+        text_block = out[0]["content"][1]
+        self.assertEqual(text_block["text"], "extract")
+        self.assertEqual(text_block["type"], "text")
+
+    def test_no_cache_control_returns_same_object(self):
+        messages = [{"role": "user", "content": "plain"}]
+        self.assertIs(LLMMessageService.strip_cache_control(messages), messages)
+
+    def test_handles_plain_string_content(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "hi",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+        ]
+        out = LLMMessageService.strip_cache_control(messages)
+        self.assertFalse(LLMMessageService.has_prompt_caching(out))
+        self.assertEqual(out[0]["content"], "sys")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/fresh_suite/unit/services/test_llm_service_vision.py
+++ b/tests/fresh_suite/unit/services/test_llm_service_vision.py
@@ -10,9 +10,10 @@ import base64
 import os
 import tempfile
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from agentmap.exceptions import LLMServiceError
+from agentmap.models.llm_execution import LLMResponse, LLMUsage
 from agentmap.services.llm_message_service import LLMMessageService
 from agentmap.services.llm_service import LLMService
 from agentmap.services.routing.types import RoutingContext
@@ -383,6 +384,161 @@ class TestSelectCandidatesVisionFiltering(unittest.TestCase):
         ctx = RoutingContext(requires_vision=False)
         # Just verify the field is False — full integration tested above
         self.assertFalse(ctx.requires_vision)
+
+
+class TestAskVisionAsync(unittest.IsolatedAsyncioTestCase):
+    """Tests for LLMService.ask_vision_async() — rich LLMResponse return."""
+
+    def setUp(self):
+        self.mock_logging_service = MockServiceFactory.create_mock_logging_service()
+        self.mock_app_config_service = (
+            MockServiceFactory.create_mock_app_config_service()
+        )
+        self.mock_llm_models_config_service = (
+            MockServiceFactory.create_mock_llm_models_config_service()
+        )
+        self.mock_routing_service = Mock()
+        self.service = LLMService(
+            configuration=self.mock_app_config_service,
+            logging_service=self.mock_logging_service,
+            routing_service=self.mock_routing_service,
+            llm_models_config_service=self.mock_llm_models_config_service,
+        )
+        self._response = LLMResponse(
+            text="Extracted text.",
+            resolved_provider="anthropic",
+            resolved_model="claude-haiku-4-5-20251001",
+            usage=LLMUsage(input_tokens=120, output_tokens=44),
+            finish_reason="end_turn",
+        )
+
+    async def test_returns_rich_llm_response(self):
+        """Returns the LLMResponse from call_llm_async unchanged."""
+        with patch.object(
+            LLMService, "call_llm_async", new=AsyncMock(return_value=self._response)
+        ) as mock_async:
+            result = await self.service.ask_vision_async(
+                prompt="Extract text.",
+                image=b"\x89PNG\r\n\x1a\n",
+                image_type="image/png",
+                provider="anthropic",
+            )
+
+        self.assertIsInstance(result, LLMResponse)
+        self.assertEqual(result.text, "Extracted text.")
+        self.assertEqual(result.usage.input_tokens, 120)
+        self.assertEqual(result.finish_reason, "end_turn")
+        mock_async.assert_awaited_once()
+
+    async def test_builds_multimodal_message(self):
+        """Constructs an image_url + text user message (non-cache path)."""
+        raw = b"img-bytes"
+        with patch.object(
+            LLMService, "call_llm_async", new=AsyncMock(return_value=self._response)
+        ) as mock_async:
+            await self.service.ask_vision_async(prompt="Describe.", image=raw)
+
+        messages = mock_async.await_args[1]["messages"]
+        self.assertEqual(messages[0]["role"], "user")
+        content = messages[0]["content"]
+        self.assertEqual(content[0]["type"], "image_url")
+        self.assertEqual(content[1]["type"], "text")
+        self.assertEqual(content[1]["text"], "Describe.")
+        expected_b64 = base64.b64encode(raw).decode("ascii")
+        self.assertIn(expected_b64, content[0]["image_url"]["url"])
+
+    async def test_injects_requires_vision_and_preserves_routing_context(self):
+        """requires_vision is added; the caller's dict is not mutated."""
+        original = {"activity": "ocr_extraction"}
+        with patch.object(
+            LLMService, "call_llm_async", new=AsyncMock(return_value=self._response)
+        ) as mock_async:
+            await self.service.ask_vision_async(
+                prompt="Extract.",
+                image=b"img",
+                routing_context=original,
+            )
+
+        rc = mock_async.await_args[1]["routing_context"]
+        self.assertTrue(rc["requires_vision"])
+        self.assertEqual(rc["activity"], "ocr_extraction")
+        self.assertNotIn("requires_vision", original)  # no mutation
+
+    async def test_cache_prompt_attaches_cache_control_and_routing_signal(self):
+        """cache_prompt marks the prompt block and requests cache-aware routing."""
+        with patch.object(
+            LLMService, "call_llm_async", new=AsyncMock(return_value=self._response)
+        ) as mock_async:
+            await self.service.ask_vision_async(
+                prompt="Long static OCR instructions.",
+                image=b"img",
+                routing_context={"activity": "ocr_extraction"},
+                cache_prompt=True,
+            )
+
+        kwargs = mock_async.await_args[1]
+        text_block = kwargs["messages"][0]["content"][1]
+        self.assertEqual(text_block["cache_control"], {"type": "ephemeral"})
+        rc = kwargs["routing_context"]
+        self.assertTrue(rc["requires_prompt_caching"])
+        self.assertTrue(rc["requires_vision"])
+
+    async def test_no_cache_control_when_cache_prompt_false(self):
+        """Default path carries no cache_control or caching routing signal."""
+        with patch.object(
+            LLMService, "call_llm_async", new=AsyncMock(return_value=self._response)
+        ) as mock_async:
+            await self.service.ask_vision_async(
+                prompt="x",
+                image=b"img",
+                routing_context={"activity": "ocr_extraction"},
+            )
+
+        kwargs = mock_async.await_args[1]
+        self.assertNotIn("cache_control", kwargs["messages"][0]["content"][1])
+        self.assertNotIn("requires_prompt_caching", kwargs["routing_context"])
+
+    async def test_default_provider_only_without_routing(self):
+        """Defaults to anthropic with no routing; stays None when routing active."""
+        with patch.object(
+            LLMService, "call_llm_async", new=AsyncMock(return_value=self._response)
+        ) as mock_async:
+            await self.service.ask_vision_async(prompt="x", image=b"img")
+        self.assertEqual(mock_async.await_args[1]["provider"], "anthropic")
+
+        with patch.object(
+            LLMService, "call_llm_async", new=AsyncMock(return_value=self._response)
+        ) as mock_async:
+            await self.service.ask_vision_async(
+                prompt="x", image=b"img", routing_context={"activity": "ocr_extraction"}
+            )
+        self.assertIsNone(mock_async.await_args[1]["provider"])
+
+
+class TestExtractFinishReason(unittest.TestCase):
+    """Tests for LLMService._extract_finish_reason()."""
+
+    def test_anthropic_stop_reason(self):
+        resp = Mock(response_metadata={"stop_reason": "max_tokens"})
+        self.assertEqual(LLMService._extract_finish_reason(resp), "max_tokens")
+
+    def test_openai_finish_reason(self):
+        resp = Mock(response_metadata={"finish_reason": "length"})
+        self.assertEqual(LLMService._extract_finish_reason(resp), "length")
+
+    def test_stop_reason_precedence_over_finish_reason(self):
+        resp = Mock(
+            response_metadata={"stop_reason": "end_turn", "finish_reason": "stop"}
+        )
+        self.assertEqual(LLMService._extract_finish_reason(resp), "end_turn")
+
+    def test_none_when_absent(self):
+        resp = Mock(response_metadata={})
+        self.assertIsNone(LLMService._extract_finish_reason(resp))
+
+    def test_none_when_metadata_not_dict(self):
+        resp = Mock(response_metadata=None)
+        self.assertIsNone(LLMService._extract_finish_reason(resp))
 
 
 if __name__ == "__main__":

--- a/tests/utils/mock_service_factory.py
+++ b/tests/utils/mock_service_factory.py
@@ -1122,6 +1122,15 @@ class MockServiceFactory:
             )
         )
         mock_service.ask_async = AsyncMock(return_value="Mock LLM response")
+        mock_service.ask_vision_async = AsyncMock(
+            return_value=LLMResponse(
+                text="Mock LLM response",
+                resolved_provider="mock-provider",
+                resolved_model="mock-model",
+                usage=None,
+                finish_reason="end_turn",
+            )
+        )
         mock_service.call_llm_many_async = AsyncMock(return_value=[])
         mock_service.get_model_name = Mock(return_value="mock-model")
         mock_service.is_available = Mock(return_value=True)


### PR DESCRIPTION
## Summary
Foundation for wormwoodGM TD-184 (consolidate all vision onto one AgentMap-routed path). Additive, no breaking changes.

- **`ask_vision_async(...) -> LLMResponse`** — builds the vision message and routes through `call_llm_async` (intelligent routing + tiered fallback + resilience). Caller passes raw bytes/path + prompt; `requires_vision=True` is injected automatically. Returns rich metadata (`resolved_provider`, `resolved_model`, `usage`, `finish_reason`).
- **`LLMResponse.finish_reason`** (`Optional[str]`) — populated from provider response metadata at the async resilience seam via `_extract_finish_reason` (e.g. `"max_tokens"` for truncation).
- **Failover-safe prompt caching** — `cache_prompt=True` attaches Anthropic `cache_control` to the prompt block and sets `routing_context["requires_prompt_caching"]` so routing keeps the **primary** pick on a cache-capable provider. The fallback handler now strips `cache_control` (`LLMMessageService.strip_cache_control`) before invoking each fallback tier, so a non-Anthropic fallback provider never receives Anthropic-only metadata and rejects it. Caching applies on the primary; failover still works.
- Added `ask_vision_async` to `LLMServiceProtocol` + `MockServiceFactory`.
- Docs: new "Pattern 4: Async vision" in `llm-service.md`, updated Tiered Fallback + Prompt-Caching Limits + `llm-config.md`.

## Test plan
- [x] Full suite green — **4964 passed, 0 failed, 149 skipped**
- [x] 36 vision tests (`test_llm_service_vision.py`) + new `strip_cache_control` unit tests
- [x] Behavioral failover UAT (in wormwoodGM): `cache_prompt=True`, primary forced to fail → non-Anthropic fallback responds with `cache_control` stripped
- [x] Codex red-team on the fix: no blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)