### PR TITLE
feat(E04-F05): retire prototype workflow router and add route-surface regression tests

### DIFF
--- a/src/agentmap/models/workflow_execution_models.py
+++ b/src/agentmap/models/workflow_execution_models.py
@@ -1,16 +1,34 @@
 """
-Workflow execution API endpoints using bundle-based approach.
+RETIRED PROTOTYPE — do not use as a production route surface.
 
-This module provides API endpoints that follow the same bundle pattern
-as the CLI, resolving workflows from the repository and using cached bundles.
+This module was a prototype async workflow router. The canonical production
+surfaces are:
+
+  HTTP routes : agentmap.deployment.http.api.routes.workflows
+                agentmap.deployment.http.api.routes.execute
+  Runtime API : agentmap.runtime_api
+  CLI         : agentmap.cli
+
+The create_workflow_router() and integrate_workflow_routes() functions below
+are tombstoned. Calling them raises RuntimeError so that any accidental
+re-registration is caught immediately rather than silently adding a
+duplicate /workflow surface to the app.
+
+Data-model classes (WorkflowExecutionRequest, WorkflowExecutionResponse, etc.)
+are preserved for reference but are not required by any canonical entrypoint.
 """
 
+import warnings
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from agentmap.di import initialize_di
+warnings.warn(
+    "agentmap.models.workflow_execution_models is a retired prototype module. "
+    "Use agentmap.deployment.http.api.routes.workflows or agentmap.runtime_api instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 # ==========================================
 # Request/Response Models
@@ -58,420 +76,63 @@ class WorkflowListResponse(BaseModel):
 # ==========================================
 
 
-def create_workflow_router(container=None) -> APIRouter:
+def create_workflow_router(container=None):  # type: ignore[return]
     """
-    Create workflow execution router with bundle support.
+    TOMBSTONED — this prototype router is retired.
 
-    This router follows the same pattern as the CLI, using
-    GraphBundleService to manage bundle caching and execution.
+    The /workflow route surface is no longer a supported production entrypoint.
+    Use the canonical routes instead:
 
-    Args:
-        container: Optional DI container (will be created if not provided)
+      agentmap.deployment.http.api.routes.workflows  (GET /workflows/*)
+      agentmap.deployment.http.api.routes.execute    (POST /execute/*)
 
-    Returns:
-        Configured APIRouter for workflow execution
+    Raises:
+        RuntimeError: Always, to prevent accidental re-registration of the
+                      prototype /workflow route surface.
     """
-    router = APIRouter(prefix="/workflow", tags=["Workflow Execution"])
-
-    # Initialize container if not provided
-    if container is None:
-        container = initialize_di()
-
-    # ==========================================
-    # Main Execution Endpoint
-    # ==========================================
-
-    @router.post("/{workflow}/{graph}", response_model=WorkflowExecutionResponse)
-    async def execute_workflow_graph(
-        workflow: str, graph: str, request: WorkflowExecutionRequest
-    ) -> WorkflowExecutionResponse:
-        """
-        Execute a specific graph from a workflow using cached bundles.
-
-        This endpoint follows the same pattern as the CLI run command:
-        1. Resolves the workflow CSV from the repository
-        2. Gets or creates a bundle using GraphBundleService
-        3. Executes the bundle
-
-        Args:
-            workflow: Workflow name (without .csv extension)
-            graph: Graph name within the workflow
-            request: Execution request with initial state
-
-        Returns:
-            Execution response with final state
-        """
-        try:
-            # Get services from container
-            app_config_service = container.app_config_service()
-            graph_bundle_service = container.graph_bundle_service()
-            graph_runner_service = container.graph_runner_service()
-            logging_service = container.logging_service()
-            logger = logging_service.get_component_logger("workflow_api")
-
-            # Resolve workflow path from repository
-            csv_repository = app_config_service.get_csv_repository_path()
-            workflow_file = csv_repository / f"{workflow}.csv"
-
-            if not workflow_file.exists():
-                # Try with .csv extension if provided
-                workflow_file = csv_repository / workflow
-                if not workflow_file.exists():
-                    raise HTTPException(
-                        status_code=404,
-                        detail=f"Workflow '{workflow}' not found in repository",
-                    )
-
-            logger.info(f"Resolved workflow path: {workflow_file}")
-
-            # Validate CSV if requested
-            if request.validate:
-                validation_service = container.validation_service()
-                try:
-                    validation_service.validate_csv_for_bundling(workflow_file)
-                    logger.info("CSV validation passed")
-                except Exception as e:
-                    raise HTTPException(
-                        status_code=400, detail=f"CSV validation failed: {str(e)}"
-                    )
-
-            # Get or create bundle (same as CLI)
-            bundle, from_cache = graph_bundle_service.get_or_create_bundle(
-                csv_path=workflow_file,
-                graph_name=graph,
-                config_path=None,  # Use default config
-            )
-
-            # Check if bundle was cached
-            bundle_cached = from_cache
-
-            # Execute using bundle
-            import time
-
-            start_time = time.time()
-
-            result = graph_runner_service.run(bundle, request.state)
-
-            execution_time = time.time() - start_time
-
-            # Build response
-            return WorkflowExecutionResponse(
-                success=result.success,
-                graph_name=bundle.graph_name or graph,
-                workflow_name=workflow,
-                final_state=result.final_state,
-                error=result.error if not result.success else None,
-                bundle_cached=bundle_cached,
-                execution_time=execution_time,
-            )
-
-        except HTTPException:
-            raise
-        except Exception as e:
-            logger.error(f"Workflow execution failed: {e}")
-            return WorkflowExecutionResponse(
-                success=False,
-                graph_name=graph,
-                workflow_name=workflow,
-                final_state=request.state,
-                error=str(e),
-            )
-
-    # ==========================================
-    # Workflow Discovery Endpoints
-    # ==========================================
-
-    @router.get("/list", response_model=WorkflowListResponse)
-    async def list_workflows() -> WorkflowListResponse:
-        """
-        List all available workflows in the repository.
-
-        Returns:
-            List of available workflows with their graphs
-        """
-        try:
-            app_config_service = container.app_config_service()
-            csv_parser_service = container.csv_graph_parser_service()
-            logging_service = container.logging_service()
-            logger = logging_service.get_component_logger("workflow_api")
-
-            # Get repository path
-            csv_repository = app_config_service.get_csv_repository_path()
-
-            # Find all CSV files
-            csv_files = list(csv_repository.glob("*.csv"))
-
-            workflows = []
-            for csv_file in csv_files:
-                try:
-                    # Parse CSV to get available graphs
-                    graph_def = csv_parser_service.parse_csv_file(csv_file)
-
-                    # Extract unique graph names
-                    graph_names = list(graph_def.keys()) if graph_def else []
-
-                    workflows.append(
-                        WorkflowInfo(
-                            name=csv_file.stem,
-                            path=str(csv_file),
-                            graphs=graph_names,
-                            size_bytes=csv_file.stat().st_size,
-                        )
-                    )
-                except Exception as e:
-                    logger.warning(f"Failed to parse {csv_file}: {e}")
-                    # Still include the workflow, just without graph info
-                    workflows.append(
-                        WorkflowInfo(
-                            name=csv_file.stem,
-                            path=str(csv_file),
-                            graphs=[],
-                            size_bytes=csv_file.stat().st_size,
-                        )
-                    )
-
-            return WorkflowListResponse(
-                workflows=workflows, repository_path=str(csv_repository)
-            )
-
-        except Exception as e:
-            logger.error(f"Failed to list workflows: {e}")
-            raise HTTPException(
-                status_code=500, detail=f"Failed to list workflows: {str(e)}"
-            )
-
-    @router.get("/{workflow}/graphs", response_model=List[str])
-    async def get_workflow_graphs(workflow: str) -> List[str]:
-        """
-        Get list of graphs available in a specific workflow.
-
-        Args:
-            workflow: Workflow name
-
-        Returns:
-            List of graph names in the workflow
-        """
-        try:
-            app_config_service = container.app_config_service()
-            csv_parser_service = container.csv_graph_parser_service()
-            logging_service = container.logging_service()
-            logger = logging_service.get_component_logger("workflow_api")
-
-            # Resolve workflow path
-            csv_repository = app_config_service.get_csv_repository_path()
-            workflow_file = csv_repository / f"{workflow}.csv"
-
-            if not workflow_file.exists():
-                workflow_file = csv_repository / workflow
-                if not workflow_file.exists():
-                    raise HTTPException(
-                        status_code=404, detail=f"Workflow '{workflow}' not found"
-                    )
-
-            # Parse CSV to get graphs
-            graph_def = csv_parser_service.parse_csv_file(workflow_file)
-
-            if not graph_def:
-                return []
-
-            return list(graph_def.keys())
-
-        except HTTPException:
-            raise
-        except Exception as e:
-            logger.error(f"Failed to get workflow graphs: {e}")
-            raise HTTPException(
-                status_code=500, detail=f"Failed to get workflow graphs: {str(e)}"
-            )
-
-    # ==========================================
-    # Bundle Management Endpoints
-    # ==========================================
-
-    @router.delete("/{workflow}/{graph}/bundle")
-    async def clear_workflow_bundle(workflow: str, graph: str) -> Dict[str, Any]:
-        """
-        Clear cached bundle for a specific workflow/graph combination.
-
-        This forces recreation on next execution.
-
-        Args:
-            workflow: Workflow name
-            graph: Graph name
-
-        Returns:
-            Status of bundle deletion
-        """
-        try:
-            app_config_service = container.app_config_service()
-            graph_bundle_service = container.graph_bundle_service()
-            graph_registry_service = container.graph_registry_service()
-            logging_service = container.logging_service()
-            logger = logging_service.get_component_logger("workflow_api")
-
-            # Resolve workflow path to get CSV hash
-            csv_repository = app_config_service.get_csv_repository_path()
-            workflow_file = csv_repository / f"{workflow}.csv"
-
-            if not workflow_file.exists():
-                workflow_file = csv_repository / workflow
-                if not workflow_file.exists():
-                    raise HTTPException(
-                        status_code=404, detail=f"Workflow '{workflow}' not found"
-                    )
-
-            # Compute CSV hash
-            from agentmap.services.graph.graph_registry_service import (
-                GraphRegistryService,
-            )
-
-            csv_hash = GraphRegistryService.compute_hash(workflow_file)
-
-            # Look up bundle
-            bundle = graph_bundle_service.lookup_bundle(csv_hash, graph)
-
-            if not bundle:
-                return {
-                    "success": False,
-                    "message": f"No cached bundle found for {workflow}/{graph}",
-                }
-
-            # Delete bundle file
-            deleted = graph_bundle_service.delete_bundle(bundle)
-
-            # Remove from registry
-            if deleted:
-                graph_registry_service.unregister(csv_hash, graph)
-
-            return {
-                "success": deleted,
-                "message": (
-                    f"Bundle cleared for {workflow}/{graph}"
-                    if deleted
-                    else "Failed to delete bundle"
-                ),
-            }
-
-        except HTTPException:
-            raise
-        except Exception as e:
-            logger.error(f"Failed to clear bundle: {e}")
-            raise HTTPException(
-                status_code=500, detail=f"Failed to clear bundle: {str(e)}"
-            )
-
-    @router.get("/bundle-info")
-    async def get_bundle_info() -> Dict[str, Any]:
-        """
-        Get information about bundle system performance and capabilities.
-
-        Returns:
-            Bundle system information
-        """
-        try:
-            graph_bundle_service = container.graph_bundle_service()
-            graph_registry_service = container.graph_registry_service()
-
-            # Get performance info
-            perf_info = graph_bundle_service.get_bundle_creation_performance_info()
-
-            # Get registry stats
-            registry_stats = graph_registry_service.get_registry_stats()
-
-            return {"bundle_system": perf_info, "registry": registry_stats}
-
-        except Exception as e:
-            raise HTTPException(
-                status_code=500, detail=f"Failed to get bundle info: {str(e)}"
-            )
-
-    return router
+    raise RuntimeError(
+        "create_workflow_router() is retired. "
+        "Register agentmap.deployment.http.api.routes.workflows and "
+        "agentmap.deployment.http.api.routes.execute instead."
+    )
 
 
 # ==========================================
-# CLI-Compatible Execution Function
+# TOMBSTONED helper functions
 # ==========================================
 
 
-def execute_workflow_from_cli_pattern(
+def execute_workflow_from_cli_pattern(  # type: ignore[return]
     workflow_name: str,
     graph_name: str,
     initial_state: Dict[str, Any],
     config_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
-    Execute workflow using the exact same pattern as the CLI.
+    TOMBSTONED — use agentmap.runtime_api.run_workflow or the CLI instead.
 
-    This function can be used for testing or direct execution
-    following the CLI pattern exactly.
-
-    Args:
-        workflow_name: Name of workflow file (without .csv)
-        graph_name: Name of graph within workflow
-        initial_state: Initial state for execution
-        config_path: Optional config file path
-
-    Returns:
-        Execution result dictionary
+    Raises:
+        RuntimeError: Always.
     """
-    # Initialize container
-    container = initialize_di(config_path)
-
-    # Get services
-    app_config_service = container.app_config_service()
-    graph_bundle_service = container.graph_bundle_service()
-    graph_runner_service = container.graph_runner_service()
-
-    # Resolve CSV path from repository
-    csv_repository = app_config_service.get_csv_repository_path()
-    csv_path = csv_repository / f"{workflow_name}.csv"
-
-    if not csv_path.exists():
-        raise FileNotFoundError(f"Workflow '{workflow_name}' not found in repository")
-
-    # Get or create bundle (exact same as CLI)
-    bundle, _ = graph_bundle_service.get_or_create_bundle(
-        csv_path=csv_path, graph_name=graph_name, config_path=config_path
+    raise RuntimeError(
+        "execute_workflow_from_cli_pattern() is retired. "
+        "Use agentmap.runtime_api or the agentmap CLI instead."
     )
 
-    # Execute using bundle
-    result = graph_runner_service.run(bundle, initial_state)
 
-    return {
-        "success": result.success,
-        "final_state": result.final_state,
-        "error": result.error,
-        "graph_name": bundle.graph_name,
-        "workflow_name": workflow_name,
-    }
-
-
-# ==========================================
-# Integration with existing FastAPI app
-# ==========================================
-
-
-def integrate_workflow_routes(app, container=None):
+def integrate_workflow_routes(app, container=None) -> None:  # type: ignore[return]
     """
-    Integrate workflow routes into existing FastAPI application.
+    TOMBSTONED — do not call this function.
 
-    Args:
-        app: FastAPI application instance
-        container: Optional DI container
+    The /workflow prototype surface is retired. Register the canonical routes:
+
+      agentmap.deployment.http.api.routes.workflows
+      agentmap.deployment.http.api.routes.execute
+
+    Raises:
+        RuntimeError: Always.
     """
-    # Create workflow router
-    workflow_router = create_workflow_router(container)
-
-    # Include in app
-    app.include_router(workflow_router)
-
-    # Add startup/shutdown events if needed
-    @app.on_event("startup")
-    async def startup_event():
-        """Initialize services on startup."""
-        pass  # Services are initialized via DI
-
-    @app.on_event("shutdown")
-    async def shutdown_event():
-        """Clean up on shutdown."""
-        pass  # Clean up if needed
+    raise RuntimeError(
+        "integrate_workflow_routes() is retired. "
+        "Use the canonical route modules in agentmap.deployment.http.api.routes instead."
+    )

--- a/src/agentmap/models/workflow_execution_models.py
+++ b/src/agentmap/models/workflow_execution_models.py
@@ -19,7 +19,7 @@ are preserved for reference but are not required by any canonical entrypoint.
 """
 
 import warnings
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, NoReturn, Optional
 
 from pydantic import BaseModel
 
@@ -76,7 +76,7 @@ class WorkflowListResponse(BaseModel):
 # ==========================================
 
 
-def create_workflow_router(_container=None):  # type: ignore[return]
+def create_workflow_router(_container=None) -> NoReturn:
     """
     TOMBSTONED — this prototype router is retired.
 
@@ -102,12 +102,12 @@ def create_workflow_router(_container=None):  # type: ignore[return]
 # ==========================================
 
 
-def execute_workflow_from_cli_pattern(  # type: ignore[return]
+def execute_workflow_from_cli_pattern(
     _workflow_name: str,
     _graph_name: str,
     _initial_state: Dict[str, Any],
     _config_path: Optional[str] = None,
-) -> Dict[str, Any]:
+) -> NoReturn:
     """
     TOMBSTONED — use agentmap.runtime_api.run_workflow or the CLI instead.
 
@@ -120,7 +120,7 @@ def execute_workflow_from_cli_pattern(  # type: ignore[return]
     )
 
 
-def integrate_workflow_routes(_app, _container=None) -> None:  # type: ignore[return]
+def integrate_workflow_routes(_app, _container=None) -> NoReturn:
     """
     TOMBSTONED — do not call this function.
 

--- a/src/agentmap/models/workflow_execution_models.py
+++ b/src/agentmap/models/workflow_execution_models.py
@@ -27,7 +27,7 @@ warnings.warn(
     "agentmap.models.workflow_execution_models is a retired prototype module. "
     "Use agentmap.deployment.http.api.routes.workflows or agentmap.runtime_api instead.",
     DeprecationWarning,
-    stacklevel=2,
+    stacklevel=1,
 )
 
 # ==========================================

--- a/src/agentmap/models/workflow_execution_models.py
+++ b/src/agentmap/models/workflow_execution_models.py
@@ -40,7 +40,7 @@ class WorkflowExecutionRequest(BaseModel):
 
     state: Dict[str, Any] = {}
     config: Optional[Dict[str, Any]] = None
-    validate: bool = False
+    validate_only: bool = False
 
 
 class WorkflowExecutionResponse(BaseModel):
@@ -76,7 +76,7 @@ class WorkflowListResponse(BaseModel):
 # ==========================================
 
 
-def create_workflow_router(container=None):  # type: ignore[return]
+def create_workflow_router(_container=None):  # type: ignore[return]
     """
     TOMBSTONED — this prototype router is retired.
 
@@ -103,10 +103,10 @@ def create_workflow_router(container=None):  # type: ignore[return]
 
 
 def execute_workflow_from_cli_pattern(  # type: ignore[return]
-    workflow_name: str,
-    graph_name: str,
-    initial_state: Dict[str, Any],
-    config_path: Optional[str] = None,
+    _workflow_name: str,
+    _graph_name: str,
+    _initial_state: Dict[str, Any],
+    _config_path: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     TOMBSTONED — use agentmap.runtime_api.run_workflow or the CLI instead.
@@ -120,7 +120,7 @@ def execute_workflow_from_cli_pattern(  # type: ignore[return]
     )
 
 
-def integrate_workflow_routes(app, container=None) -> None:  # type: ignore[return]
+def integrate_workflow_routes(_app, _container=None) -> None:  # type: ignore[return]
     """
     TOMBSTONED — do not call this function.
 

--- a/tests/fresh_suite/integration/api/test_workflow_endpoints.py
+++ b/tests/fresh_suite/integration/api/test_workflow_endpoints.py
@@ -781,6 +781,138 @@ edge_graph,node-with-dashes,default,Test dashes in names,Node with dashes,output
 
         self.run_with_admin_auth(run_test)
 
+    # ==========================================
+    # TC-001 / TC-002: Prototype Route Retirement Regression Coverage
+    # ==========================================
+
+    def test_prototype_workflow_routes_absent_from_app(self):
+        """
+        TC-001: Production app route surface excludes the prototype workflow router.
+
+        Build the FastAPI app with the normal create_fastapi_app() path and verify
+        that no /workflow prototype routes appear in app.routes or the OpenAPI schema.
+        The canonical /workflows and /execute routes must be present.
+        """
+        # Collect all registered route paths
+        route_paths = []
+        for route in self.app.routes:
+            if hasattr(route, "path"):
+                route_paths.append(route.path)
+
+        # AC-T1: The prototype /workflow prefix routes must be absent
+        prototype_routes = [
+            p for p in route_paths if p.startswith("/workflow/") or p == "/workflow"
+        ]
+        self.assertEqual(
+            prototype_routes,
+            [],
+            f"Prototype /workflow routes found in app: {prototype_routes}. "
+            "These must be absent from the production app.",
+        )
+
+        # The canonical routes must be present (sanity check)
+        canonical_prefixes = ["/workflows", "/execute"]
+        for prefix in canonical_prefixes:
+            matching = [p for p in route_paths if p.startswith(prefix)]
+            self.assertTrue(
+                len(matching) > 0,
+                f"Canonical route prefix '{prefix}' not found in app routes: {route_paths}",
+            )
+
+    def test_prototype_workflow_routes_absent_from_openapi_schema(self):
+        """
+        TC-001 (OpenAPI variant): OpenAPI paths exclude the prototype /workflow surface.
+
+        Inspect the OpenAPI schema produced by the running app to verify no
+        /workflow/* prototype paths appear. Edge cases: URL-encoded paths,
+        duplicate registrations.
+        """
+        response = self.client.get("/openapi.json")
+        self.assertEqual(
+            response.status_code,
+            200,
+            f"Could not retrieve OpenAPI schema: {response.text}",
+        )
+
+        schema = response.json()
+        openapi_paths = list(schema.get("paths", {}).keys())
+
+        # AC-T1: No /workflow prototype paths in OpenAPI schema
+        prototype_paths = [
+            p for p in openapi_paths if p.startswith("/workflow/") or p == "/workflow"
+        ]
+        self.assertEqual(
+            prototype_paths,
+            [],
+            f"Prototype /workflow paths found in OpenAPI schema: {prototype_paths}. "
+            "These must be absent from the production API surface.",
+        )
+
+        # Canonical /workflows and /execute paths must be present
+        canonical_present = [
+            p
+            for p in openapi_paths
+            if p.startswith("/workflows") or p.startswith("/execute")
+        ]
+        self.assertTrue(
+            len(canonical_present) > 0,
+            f"No canonical workflow or execution paths found in OpenAPI schema: {openapi_paths}",
+        )
+
+    def test_canonical_imports_do_not_require_prototype_module(self):
+        """
+        TC-002: Canonical runtime import surfaces do not require the prototype module.
+
+        Import agentmap.runtime and agentmap.runtime_api, then verify app creation
+        succeeds without the prototype module being a transitive dependency for
+        supported workflows.
+        """
+        import sys
+
+        # The prototype module must NOT be imported by canonical surfaces.
+        # Clear it from the module cache to simulate a fresh import check.
+        prototype_module_name = "agentmap.models.workflow_execution_models"
+
+        # Record whether prototype was already loaded (it may be from earlier tests)
+        was_loaded_before = prototype_module_name in sys.modules
+
+        # Import canonical surfaces - these should work independently
+        import agentmap.runtime  # noqa: F401
+        import agentmap.runtime_api  # noqa: F401
+
+        # Verify canonical surfaces are importable and provide expected callables
+        self.assertTrue(
+            hasattr(agentmap.runtime_api, "ensure_initialized"),
+            "agentmap.runtime_api must export ensure_initialized",
+        )
+        self.assertTrue(
+            hasattr(agentmap.runtime_api, "get_container"),
+            "agentmap.runtime_api must export get_container",
+        )
+
+        # The app was already created in setUp without importing the prototype module.
+        # Confirm the canonical app routes are intact.
+        route_paths = [
+            route.path for route in self.app.routes if hasattr(route, "path")
+        ]
+        canonical_routes = [
+            p
+            for p in route_paths
+            if p.startswith("/workflows") or p.startswith("/execute")
+        ]
+        self.assertTrue(
+            len(canonical_routes) > 0,
+            "Canonical routes must be present even without prototype module import.",
+        )
+
+        # If the prototype module was NOT loaded before, it should still not be
+        # loaded now (canonical surfaces don't require it).
+        if not was_loaded_before:
+            # Note: if it was loaded later by some other import, that is outside
+            # the scope of this test — we only check the canonical surfaces don't
+            # pull it in transitively during setUp.
+            pass  # The setUp created the app; prototype module was not needed.
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/fresh_suite/integration/api/test_workflow_endpoints.py
+++ b/tests/fresh_suite/integration/api/test_workflow_endpoints.py
@@ -863,24 +863,29 @@ edge_graph,node-with-dashes,default,Test dashes in names,Node with dashes,output
         """
         TC-002: Canonical runtime import surfaces do not require the prototype module.
 
-        Import agentmap.runtime and agentmap.runtime_api, then verify app creation
-        succeeds without the prototype module being a transitive dependency for
-        supported workflows.
+        Ensure the prototype module is absent from sys.modules (clean slate), then
+        build a fresh app via create_fastapi_app() and assert the prototype module is
+        still absent afterwards.  This test FAILS if any code path reached by canonical
+        startup imports agentmap.models.workflow_execution_models as a side effect.
+
+        Strategy: we cannot re-execute agentmap.runtime's init code because it is
+        already cached in sys.modules from setUp.  Instead we (a) guarantee proto is
+        absent going in and (b) call create_fastapi_app() — which is never cached —
+        to trigger any lazy imports that canonical startup exercises.  If proto appears
+        after that call, a regression has been introduced.
         """
         import sys
 
-        # The prototype module must NOT be imported by canonical surfaces.
-        # Clear it from the module cache to simulate a fresh import check.
-        prototype_module_name = "agentmap.models.workflow_execution_models"
+        proto = "agentmap.models.workflow_execution_models"
 
-        # Record whether prototype was already loaded (it may be from earlier tests)
-        was_loaded_before = prototype_module_name in sys.modules
+        # Guarantee a clean slate: remove any previously-loaded copy of the
+        # prototype module so the assertNotIn below is meaningful.
+        sys.modules.pop(proto, None)
 
-        # Import canonical surfaces - these should work independently
-        import agentmap.runtime  # noqa: F401
+        # The canonical surfaces (agentmap.runtime, agentmap.runtime_api) are
+        # already loaded from setUp — confirm the expected callables are present.
         import agentmap.runtime_api  # noqa: F401
 
-        # Verify canonical surfaces are importable and provide expected callables
         self.assertTrue(
             hasattr(agentmap.runtime_api, "ensure_initialized"),
             "agentmap.runtime_api must export ensure_initialized",
@@ -890,28 +895,32 @@ edge_graph,node-with-dashes,default,Test dashes in names,Node with dashes,output
             "agentmap.runtime_api must export get_container",
         )
 
-        # The app was already created in setUp without importing the prototype module.
-        # Confirm the canonical app routes are intact.
-        route_paths = [
-            route.path for route in self.app.routes if hasattr(route, "path")
-        ]
-        canonical_routes = [
-            p
-            for p in route_paths
-            if p.startswith("/workflows") or p.startswith("/execute")
-        ]
-        self.assertTrue(
-            len(canonical_routes) > 0,
-            "Canonical routes must be present even without prototype module import.",
+        # Build a fresh app — do NOT reuse self.app (built in setUp before this
+        # test ran).  create_fastapi_app() is never cached; calling it here
+        # exercises every import that canonical app construction triggers.
+        from agentmap.deployment.http.api.server import create_fastapi_app
+
+        fresh_app = create_fastapi_app()
+
+        # AC-002 / REQ-NF-001: the prototype module must NOT have appeared in
+        # sys.modules as a side-effect of canonical runtime surfaces or app
+        # construction.  If it does, a re-coupling regression has been introduced.
+        self.assertNotIn(
+            proto,
+            sys.modules,
+            "Canonical runtime/app surfaces must not import the retired prototype module.",
         )
 
-        # If the prototype module was NOT loaded before, it should still not be
-        # loaded now (canonical surfaces don't require it).
-        if not was_loaded_before:
-            # Note: if it was loaded later by some other import, that is outside
-            # the scope of this test — we only check the canonical surfaces don't
-            # pull it in transitively during setUp.
-            pass  # The setUp created the app; prototype module was not needed.
+        # Sanity check: canonical routes must be present in the fresh app.
+        route_paths = [r.path for r in fresh_app.routes if hasattr(r, "path")]
+        self.assertTrue(
+            any(p.startswith("/workflows") for p in route_paths),
+            f"Canonical /workflows routes must be present in fresh app. Routes: {route_paths}",
+        )
+        self.assertTrue(
+            any(p.startswith("/execute") for p in route_paths),
+            f"Canonical /execute routes must be present in fresh app. Routes: {route_paths}",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/fresh_suite/integration/api/test_workflow_endpoints.py
+++ b/tests/fresh_suite/integration/api/test_workflow_endpoints.py
@@ -5,6 +5,7 @@ Tests the FastAPI workflow routes for managing workflows in the CSV repository,
 using real DI container and service implementations.
 """
 
+import sys
 import unittest
 from pathlib import Path
 
@@ -793,15 +794,13 @@ edge_graph,node-with-dashes,default,Test dashes in names,Node with dashes,output
         that no /workflow prototype routes appear in app.routes or the OpenAPI schema.
         The canonical /workflows and /execute routes must be present.
         """
-        # Collect all registered route paths
-        route_paths = []
-        for route in self.app.routes:
-            if hasattr(route, "path"):
-                route_paths.append(route.path)
+        route_paths = [r.path for r in self.app.routes if hasattr(r, "path")]
 
         # AC-T1: The prototype /workflow prefix routes must be absent
         prototype_routes = [
-            p for p in route_paths if p.startswith("/workflow/") or p == "/workflow"
+            p
+            for p in route_paths
+            if p.startswith("/workflow") and not p.startswith("/workflows")
         ]
         self.assertEqual(
             prototype_routes,
@@ -839,7 +838,9 @@ edge_graph,node-with-dashes,default,Test dashes in names,Node with dashes,output
 
         # AC-T1: No /workflow prototype paths in OpenAPI schema
         prototype_paths = [
-            p for p in openapi_paths if p.startswith("/workflow/") or p == "/workflow"
+            p
+            for p in openapi_paths
+            if p.startswith("/workflow") and not p.startswith("/workflows")
         ]
         self.assertEqual(
             prototype_paths,
@@ -874,13 +875,18 @@ edge_graph,node-with-dashes,default,Test dashes in names,Node with dashes,output
         to trigger any lazy imports that canonical startup exercises.  If proto appears
         after that call, a regression has been introduced.
         """
-        import sys
-
         proto = "agentmap.models.workflow_execution_models"
 
         # Guarantee a clean slate: remove any previously-loaded copy of the
         # prototype module so the assertNotIn below is meaningful.
-        sys.modules.pop(proto, None)
+        original = sys.modules.pop(proto, None)
+        self.addCleanup(
+            lambda: (
+                sys.modules.update({proto: original})
+                if original is not None
+                else sys.modules.pop(proto, None)
+            )
+        )
 
         # The canonical surfaces (agentmap.runtime, agentmap.runtime_api) are
         # already loaded from setUp — confirm the expected callables are present.
@@ -921,6 +927,43 @@ edge_graph,node-with-dashes,default,Test dashes in names,Node with dashes,output
             any(p.startswith("/execute") for p in route_paths),
             f"Canonical /execute routes must be present in fresh app. Routes: {route_paths}",
         )
+
+    def test_retired_module_emits_deprecation_warning_on_import(self):
+        """TC-003: Importing the retired module emits a DeprecationWarning pointing to canonical surfaces."""
+        proto = "agentmap.models.workflow_execution_models"
+        original = sys.modules.pop(proto, None)
+        self.addCleanup(
+            lambda: (
+                sys.modules.update({proto: original})
+                if original is not None
+                else sys.modules.pop(proto, None)
+            )
+        )
+        import warnings
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            import agentmap.models.workflow_execution_models  # noqa: F401
+        self.assertEqual(
+            len(caught), 1, f"Expected exactly 1 DeprecationWarning, got: {caught}"
+        )
+        self.assertIs(caught[0].category, DeprecationWarning)
+        self.assertIn("retired prototype", str(caught[0].message).lower())
+
+    def test_tombstoned_functions_raise_runtime_error(self):
+        """TC-004: All tombstoned router functions raise RuntimeError immediately."""
+        from agentmap.models.workflow_execution_models import (
+            create_workflow_router,
+            execute_workflow_from_cli_pattern,
+            integrate_workflow_routes,
+        )
+
+        with self.assertRaises(RuntimeError):
+            create_workflow_router()
+        with self.assertRaises(RuntimeError):
+            integrate_workflow_routes(None)
+        with self.assertRaises(RuntimeError):
+            execute_workflow_from_cli_pattern("w", "g", {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Tombstones the prototype `/workflow` route surface in `agentmap.models.workflow_execution_models` — factory and helper functions now raise `RuntimeError` immediately to prevent accidental re-registration
- Emits a `DeprecationWarning` on module import to signal the retired state to any downstream callers
- Adds 5 regression tests covering: prototype routes absent from app routes (TC-001), absent from OpenAPI schema (TC-001 OpenAPI), canonical startup independent of prototype module (TC-002), deprecation warning on import (TC-003), all tombstoned functions raise RuntimeError (TC-004)
- Updates 5 planning/review docs to describe the route as tombstoned/retired and point to canonical surfaces
- Fixes `NoReturn` typing on tombstoned functions, tightens route filter predicates, and addresses test-isolation hygiene

## Test plan

- [x] `make format && make lint` — clean
- [x] TC-001: `test_prototype_workflow_routes_absent_from_app` — prototype `/workflow` routes absent, canonical `/workflows` + `/execute` present
- [x] TC-001 (OpenAPI): `test_prototype_workflow_routes_absent_from_openapi_schema` — same check against `/openapi.json`
- [x] TC-002: `test_canonical_imports_do_not_require_prototype_module` — `create_fastapi_app()` does not re-import prototype module; verified with counter-factual injection
- [x] TC-003: `test_retired_module_emits_deprecation_warning_on_import` — DeprecationWarning fires on import with canonical redirect text
- [x] TC-004: `test_tombstoned_functions_raise_runtime_error` — all three tombstoned functions raise RuntimeError
- [x] Full suite: 4613 passed, 0 failed, 149 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)