### PR TITLE
fix(graph-agent): remap subgraph outputs to parent fields

### DIFF
--- a/examples/subgraph_mapping/README.md
+++ b/examples/subgraph_mapping/README.md
@@ -1,0 +1,108 @@
+# GraphAgent Subgraph Mapping Examples
+
+Runnable examples showing how parent and child graph state move through the
+`graph` agent.
+
+## Files
+
+```text
+subgraph_mapping/
+├── agentmap_config.yaml
+├── agentmap_config_storage.yaml
+├── run_example.py
+├── README.md
+└── workflows/
+    ├── ChildInputPassThrough.csv
+    ├── DirectSubgraphState.csv
+    └── OutputRemapExample.csv
+```
+
+## What Each Example Shows
+
+### 1. `DirectSubgraphState`
+
+`Output_Field: inner_result`
+
+The parent stores the entire child graph final state under `inner_result`.
+This is the simplest pattern when the parent wants the whole child result as a
+nested object.
+
+Relevant fields:
+
+```python
+{
+    "inner_result": {
+        "raw_data": "hello from parent",
+        "child_value": "hello from parent",
+        "child_final": "hello from parent",
+    },
+    "final_result": {
+        "raw_data": "hello from parent",
+        "child_value": "hello from parent",
+        "child_final": "hello from parent",
+    },
+}
+```
+
+### 2. `ChildInputPassThrough`
+
+`Input_Fields: text|request_id`
+
+The GraphAgent forwards exactly the listed parent fields into the child graph.
+The child sees `text` and `request_id` in its own initial state and returns a
+snapshot of those values.
+
+Relevant fields:
+
+```python
+{
+    "child_result": {
+        "text": "passed straight into child text",
+        "request_id": "req-42",
+        "child_snapshot": {
+            "text": "passed straight into child text",
+            "request_id": "req-42",
+        },
+    }
+}
+```
+
+### 3. `OutputRemapExample`
+
+`Output_Field: selected_parent=child_final`
+
+The child produces `child_final`, and the GraphAgent writes that value into the
+parent field `selected_parent`. The next parent node reads `selected_parent`
+like any other top-level state key.
+
+Relevant fields:
+
+```python
+{
+    "selected_parent": "mapped back to parent",
+    "echoed_parent": "mapped back to parent",
+}
+```
+
+## Run
+
+From the repository root:
+
+```bash
+uv run python examples/subgraph_mapping/run_example.py
+```
+
+Or from this directory:
+
+```bash
+UV_CACHE_DIR=/tmp/uv-cache uv run python run_example.py
+```
+
+## Mapping Rules
+
+- Standard framework input remap: `state_key:param_name`
+- GraphAgent child input selection: `field_a|field_b`
+- GraphAgent output remap: `parent_key=child_key`
+
+The GraphAgent output remap uses `target=source`, which is the reverse of the
+framework-wide `:` input mapping syntax.

--- a/examples/subgraph_mapping/agentmap_config.yaml
+++ b/examples/subgraph_mapping/agentmap_config.yaml
@@ -1,0 +1,23 @@
+storage_config_path: "agentmap_config_storage.yaml"
+
+paths:
+  csv_repository: "workflows"
+
+execution:
+  state_schema: "dynamic"
+  enable_validation: true
+
+logging:
+  version: 1
+  disable_existing_loggers: false
+  formatters:
+    default:
+      format: "[%(asctime)s] [%(levelname)s] %(name)s: %(message)s"
+  handlers:
+    console:
+      class: logging.StreamHandler
+      formatter: default
+      level: INFO
+  root:
+    level: INFO
+    handlers: [console]

--- a/examples/subgraph_mapping/agentmap_config_storage.yaml
+++ b/examples/subgraph_mapping/agentmap_config_storage.yaml
@@ -1,0 +1,10 @@
+base_directory: "agentmap_data"
+
+csv:
+  default_path: "workflows"
+
+json:
+  default_path: "agentmap_data/json"
+
+file:
+  default_path: "agentmap_data/files"

--- a/examples/subgraph_mapping/run_example.py
+++ b/examples/subgraph_mapping/run_example.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Run GraphAgent subgraph mapping examples.
+"""
+
+import os
+import sys
+from pathlib import Path
+from pprint import pprint
+
+EXAMPLE_DIR = Path(__file__).resolve().parent
+REPO_ROOT = EXAMPLE_DIR.parents[1]
+
+sys.path.insert(0, str(REPO_ROOT / "src"))
+os.chdir(EXAMPLE_DIR)
+
+from agentmap import run_workflow
+
+
+def clean_outputs(outputs):
+    """Remove execution metadata so the mapping behavior is easier to inspect."""
+    if isinstance(outputs, dict):
+        cleaned = {}
+        for key, value in outputs.items():
+            if key in {"__execution_summary", "__policy_success", "subgraph_bundles"}:
+                continue
+            cleaned[key] = clean_outputs(value)
+        return cleaned
+    if isinstance(outputs, list):
+        return [clean_outputs(item) for item in outputs]
+    return outputs
+
+
+def run_case(title, graph_name, inputs):
+    print("=" * 72)
+    print(title)
+    print("=" * 72)
+    print(f"Graph:  {graph_name}")
+    print(f"Inputs: {inputs}")
+
+    result = run_workflow(graph_name, inputs)
+    print("Success:", result["success"])
+    pprint(clean_outputs(result["outputs"]))
+    print()
+
+
+def main():
+    run_case(
+        "Example 1: Store the entire child final state under one parent field",
+        "DirectSubgraphState",
+        {"raw_data": "hello from parent"},
+    )
+
+    run_case(
+        "Example 2: Pass selected parent fields straight into the child graph",
+        "ChildInputPassThrough",
+        {"text": "passed straight into child text", "request_id": "req-42"},
+    )
+
+    run_case(
+        "Example 3: Remap child child_final -> parent selected_parent on return",
+        "OutputRemapExample",
+        {"raw_data": "mapped back to parent"},
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/subgraph_mapping/workflows/ChildInputPassThrough.csv
+++ b/examples/subgraph_mapping/workflows/ChildInputPassThrough.csv
@@ -1,0 +1,4 @@
+GraphName,Node,AgentType,Prompt,Input_Fields,Output_Field,Edge,Success_Next,Failure_Next,Context
+ChildInputPassThrough,CallInner,graph,Pass selected parent fields into child state,text|request_id,child_result,Done,,,{workflow=::ChildInputPassThroughInner}
+ChildInputPassThrough,Done,echo,Return full child result,child_result,final_result,,,,
+ChildInputPassThroughInner,InspectText,echo,Read the selected child input,text|request_id,child_snapshot,,,,

--- a/examples/subgraph_mapping/workflows/DirectSubgraphState.csv
+++ b/examples/subgraph_mapping/workflows/DirectSubgraphState.csv
@@ -1,0 +1,5 @@
+GraphName,Node,AgentType,Prompt,Input_Fields,Output_Field,Edge,Success_Next,Failure_Next,Context
+DirectSubgraphState,CallInner,graph,Run child graph,raw_data,inner_result,Done,,,{workflow=::DirectSubgraphStateInner}
+DirectSubgraphState,Done,echo,Return nested child result,inner_result,final_result,,,,
+DirectSubgraphStateInner,CopyInput,echo,Copy parent data into child state,raw_data,child_value,Summarize,,,
+DirectSubgraphStateInner,Summarize,echo,Expose final child field,child_value,child_final,,,,

--- a/examples/subgraph_mapping/workflows/OutputRemapExample.csv
+++ b/examples/subgraph_mapping/workflows/OutputRemapExample.csv
@@ -1,0 +1,4 @@
+GraphName,Node,AgentType,Prompt,Input_Fields,Output_Field,Edge,Success_Next,Failure_Next,Context
+OutputRemapExample,CallInner,graph,Map a child field back to the parent,raw_data,selected_parent=child_final,ReadMapped,,,{workflow=::OutputRemapInner}
+OutputRemapExample,ReadMapped,echo,Read mapped parent field,selected_parent,echoed_parent,,,,
+OutputRemapInner,MakeChildValue,echo,Expose final child value,raw_data,child_final,,,,

--- a/src/agentmap/agents/builtins/graph_agent.py
+++ b/src/agentmap/agents/builtins/graph_agent.py
@@ -234,14 +234,29 @@ class GraphAgent(BaseAgent, GraphBundleCapableAgent, GraphRunnerCapableAgent):
                 "graph_success", output.get("last_action_success", True)
             )
 
-            state_updates = {
-                self.output_field: output,
-                "last_action_success": graph_success,
-            }
+            state_updates = self._build_state_updates(output, graph_success)
 
             return state, {"state_updates": state_updates}
 
         return state, output
+
+    def _build_state_updates(
+        self, output: Dict[str, Any], graph_success: Any
+    ) -> Dict[str, Any]:
+        """Build parent state updates for graph outputs."""
+        target_field = self._get_output_mapping_target()
+
+        if target_field:
+            mapped_value = output[target_field] if target_field in output else output
+            return {
+                target_field: mapped_value,
+                "last_action_success": graph_success,
+            }
+
+        return {
+            self.output_field: output,
+            "last_action_success": graph_success,
+        }
 
     def _prepare_subgraph_state(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -335,8 +350,9 @@ class GraphAgent(BaseAgent, GraphBundleCapableAgent, GraphRunnerCapableAgent):
             Processed result for parent graph
         """
         # Handle output field mapping
-        if self.output_field and "=" in self.output_field:
-            target_field, source_field = self.output_field.split("=", 1)
+        target_field = self._get_output_mapping_target()
+        if target_field:
+            _, source_field = self.output_field.split("=", 1)
             if source_field in result:
                 processed = {target_field: result[source_field]}
                 self.log_debug(
@@ -350,3 +366,10 @@ class GraphAgent(BaseAgent, GraphBundleCapableAgent, GraphRunnerCapableAgent):
 
         # Default: return entire result
         return result
+
+    def _get_output_mapping_target(self) -> Optional[str]:
+        """Return the parent target field for `target=source` output mapping."""
+        if self.output_field and "=" in self.output_field:
+            target_field, _ = self.output_field.split("=", 1)
+            return target_field
+        return None

--- a/tests/fresh_suite/integration/test_two_layer_graph_integration.py
+++ b/tests/fresh_suite/integration/test_two_layer_graph_integration.py
@@ -37,6 +37,22 @@ TestInner,Process,default,data,processed,InnerDone,,,Process inner data
 TestInner,InnerDone,default,processed|data,inner_final,,,,Return inner result
 """
 
+    MAPPED_OUTPUT_CSV = """\
+GraphName,Node,AgentType,Input_Fields,Output_Field,Success_Next,Failure_Next,Context,Prompt
+TestOuter,Start,echo,input,data,CallInner,,,Initialize data
+TestOuter,CallInner,graph,data,selected_parent=child_final,ReadMapped,,{workflow=::TestInner},Call inner graph
+TestOuter,ReadMapped,echo,selected_parent,echoed_parent,,,,Read mapped parent field
+TestInner,Process,echo,data,processed,InnerDone,,,Process inner data
+TestInner,InnerDone,echo,processed,child_final,,,,Return inner result
+"""
+
+    DIRECT_CHILD_INPUT_CSV = """\
+GraphName,Node,AgentType,Input_Fields,Output_Field,Success_Next,Failure_Next,Context,Prompt
+TestOuter,CallInner,graph,text|request_id,child_result,Done,,{workflow=::TestInner},Call inner graph
+TestOuter,Done,echo,child_result,final_result,,,,Return child result
+TestInner,InspectText,echo,text|request_id,child_snapshot,,,,Read selected child state
+"""
+
     def setup_services(self):
         """Initialize services needed for graph execution."""
         super().setup_services()
@@ -137,6 +153,56 @@ TestInner,InnerDone,default,processed|data,inner_final,,,,Return inner result
                 result.success,
                 f"Legacy resolution should succeed. Error: {result.error}",
             )
+
+    def test_output_field_mapping_updates_parent_target_field(self):
+        """Mapped graph outputs should be readable by the next parent node."""
+        csv_path = self._create_two_layer_csv(
+            filename="mapped_output_two_layer.csv",
+            content=self.MAPPED_OUTPUT_CSV,
+        )
+
+        bundle, _ = self.graph_bundle_service.get_or_create_bundle(
+            csv_path=csv_path,
+            graph_name="TestOuter",
+        )
+
+        result = self.graph_runner_service.run(bundle, initial_state={"input": "hello"})
+
+        from agentmap.models.execution.result import ExecutionResult
+
+        self.assertIsInstance(result, ExecutionResult)
+        self.assertTrue(result.success, f"Mapped output flow failed: {result.error}")
+        self.assertEqual(result.final_state["selected_parent"], "hello")
+        self.assertEqual(result.final_state["echoed_parent"], "hello")
+
+    def test_selected_parent_fields_are_forwarded_to_child_graph(self):
+        """GraphAgent should pass selected parent fields into child state."""
+        csv_path = self._create_two_layer_csv(
+            filename="direct_child_input_two_layer.csv",
+            content=self.DIRECT_CHILD_INPUT_CSV,
+        )
+
+        bundle, _ = self.graph_bundle_service.get_or_create_bundle(
+            csv_path=csv_path,
+            graph_name="TestOuter",
+        )
+
+        result = self.graph_runner_service.run(
+            bundle,
+            initial_state={"text": "hello", "request_id": "req-42"},
+        )
+
+        from agentmap.models.execution.result import ExecutionResult
+
+        self.assertIsInstance(result, ExecutionResult)
+        self.assertTrue(result.success, f"Selected child input flow failed: {result.error}")
+        self.assertEqual(
+            result.final_state["child_result"]["child_snapshot"]["text"], "hello"
+        )
+        self.assertEqual(
+            result.final_state["child_result"]["child_snapshot"]["request_id"],
+            "req-42",
+        )
 
     # --- Unit-level checks ---
 

--- a/tests/fresh_suite/integration/test_two_layer_graph_integration.py
+++ b/tests/fresh_suite/integration/test_two_layer_graph_integration.py
@@ -195,7 +195,9 @@ TestInner,InspectText,echo,text|request_id,child_snapshot,,,,Read selected child
         from agentmap.models.execution.result import ExecutionResult
 
         self.assertIsInstance(result, ExecutionResult)
-        self.assertTrue(result.success, f"Selected child input flow failed: {result.error}")
+        self.assertTrue(
+            result.success, f"Selected child input flow failed: {result.error}"
+        )
         self.assertEqual(
             result.final_state["child_result"]["child_snapshot"]["text"], "hello"
         )

--- a/tests/fresh_suite/unit/agents/test_graph_agent.py
+++ b/tests/fresh_suite/unit/agents/test_graph_agent.py
@@ -739,6 +739,25 @@ class TestGraphAgent(unittest.TestCase):
         # Verify result is included in state_updates
         self.assertEqual(state_updates["result"], output)
 
+    def test_post_process_uses_mapped_output_target_field(self):
+        """Test post-processing writes mapped graph output to the parsed parent key."""
+        context = {"output_field": "selected_parent=child_final"}
+        agent = self.create_graph_agent(context=context)
+        agent.set_execution_tracker(self.mock_tracker)
+
+        output = {"selected_parent": "hello"}
+
+        updated_state, processed_output = agent._post_process({}, {}, output)
+
+        self.assertEqual(updated_state, {})
+        self.assertEqual(
+            processed_output["state_updates"],
+            {
+                "selected_parent": "hello",
+                "last_action_success": True,
+            },
+        )
+
     # =============================================================================
     # 7. Logging Integration Tests
     # =============================================================================


### PR DESCRIPTION
## Summary
- fix GraphAgent parent state updates so Output_Field mappings like parent=child write to the parsed parent key
- add regression coverage for mapped output return paths and direct child input passthrough
- include runnable subgraph mapping examples documenting direct child state, selected child inputs, and output remapping

## Test plan
- [x] UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/fresh_suite/unit/agents/test_graph_agent.py -q
- [x] UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/fresh_suite/integration/test_two_layer_graph_integration.py -q
- [x] UV_CACHE_DIR=/tmp/uv-cache uv run python examples/subgraph_mapping/run_example.py

🤖 Generated with Codex
