### PR TITLE
Format GraphAgent B004 files and add review report

### DIFF
--- a/src/agentmap/agents/builtins/graph_agent.py
+++ b/src/agentmap/agents/builtins/graph_agent.py
@@ -330,7 +330,10 @@ class GraphAgent(BaseAgent, GraphBundleCapableAgent, GraphRunnerCapableAgent):
                 field_value = self.state_adapter_service.get_value(
                     parent_state, field_spec, self._MISSING
                 )
-                if field_spec != "subgraph_bundles" and field_value is not self._MISSING:
+                if (
+                    field_spec != "subgraph_bundles"
+                    and field_value is not self._MISSING
+                ):
                     subgraph_state[field_spec] = field_value
                     self.log_debug(f"[GraphAgent] Passed through {field_spec}")
 

--- a/tests/fresh_suite/unit/agents/test_graph_agent.py
+++ b/tests/fresh_suite/unit/agents/test_graph_agent.py
@@ -296,7 +296,9 @@ class TestGraphAgent(unittest.TestCase):
         }
         self.assertEqual(result, expected)
 
-    def test_prepare_subgraph_state_field_mapping_uses_parent_state_from_preprocess(self):
+    def test_prepare_subgraph_state_field_mapping_uses_parent_state_from_preprocess(
+        self,
+    ):
         """Mapped child inputs should resolve from the original parent state."""
         context = {"input_fields": ["text=raw_data", "request_id"]}
         agent = self.create_graph_agent(context=context)


### PR DESCRIPTION
## Summary
- reformat the existing GraphAgent B004 lines for readability
- reformat the matching unit test method signature
- add the persisted deep-review report for this branch

## Test plan
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/fresh_suite/unit/agents/test_graph_agent.py -q
- UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/fresh_suite/integration/test_two_layer_graph_integration.py -q

## Notes
- the underlying GraphAgent remap fix and regression test were already present on main before this branch
- AGENTS.md has no local diff in this worktree
- DEVELOPMENT.md does not exist in this repository